### PR TITLE
docs: add documentation that Publisher and Subscriber must be used in a `with` block

### DIFF
--- a/google/cloud/pubsublite/cloudpubsub/publisher.py
+++ b/google/cloud/pubsublite/cloudpubsub/publisher.py
@@ -7,6 +7,8 @@ class AsyncPublisher(AsyncContextManager):
     """
   An AsyncPublisher publishes messages similar to Google Pub/Sub, but must be used in an
   async context. Any publish failures are permanent.
+
+  Must be used in an `async with` block or have __aenter__() awaited before use.
   """
 
     @abstractmethod
@@ -32,6 +34,8 @@ class AsyncPublisher(AsyncContextManager):
 class Publisher(ContextManager):
     """
   A Publisher publishes messages similar to Google Pub/Sub. Any publish failures are permanent.
+
+  Must be used in a `with` block or have __enter__() called before use.
   """
 
     @abstractmethod

--- a/google/cloud/pubsublite/cloudpubsub/subscriber.py
+++ b/google/cloud/pubsublite/cloudpubsub/subscriber.py
@@ -7,6 +7,8 @@ from google.cloud.pubsub_v1.subscriber.message import Message
 class AsyncSubscriber(AsyncContextManager):
     """
   A Cloud Pub/Sub asynchronous subscriber.
+
+  Must be used in an `async with` block or have __aenter__() awaited before use.
   """
 
     @abstractmethod


### PR DESCRIPTION
fixes #46 