### PR TITLE
chore: require presumbit tests to pass samples testing against HEAD

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -30,6 +30,10 @@ branchProtectionRules:
   requiredStatusCheckContexts:
     - 'Kokoro'
     - 'cla/google'
+    - 'Samples - Python 3.6'
+    - 'Samples - Python 3.7'
+    - 'Samples - Python 3.8'
+    - 'Samples - Lint'
 # List of explicit permissions to add (additive only)
 permissionRules:
     # Team slug to add to repository permissions


### PR DESCRIPTION
This should have been a requirement from the start.

Presubmit tests for samples run against head and should be a requirement. 

See

1. https://github.com/googleapis/python-pubsublite/blob/master/.kokoro/samples/python3.6/presubmit.cfg
2. https://github.com/googleapis/python-pubsublite/blob/0573edbefdf2612b2006b51829d1fd8fa636de3c/samples/snippets/noxfile.py#L88 