### PR TITLE
fix: catch InternalServerError for non-existent topics

### DIFF
--- a/samples/snippets/quickstart_test.py
+++ b/samples/snippets/quickstart_test.py
@@ -19,7 +19,7 @@ import random
 import uuid
 
 import backoff
-from google.api_core.exceptions import NotFound
+from google.api_core.exceptions import InternalServerError, NotFound
 from google.cloud.pubsublite import AdminClient
 from google.cloud.pubsublite.types import (
     CloudRegion,
@@ -53,8 +53,8 @@ def topic_path(client):
     yield topic_path
     try:
         client.delete_topic(topic_path)
-    except NotFound:
-        pass
+    except (InternalServerError, NotFound) as e:
+        print(e)
 
 
 @pytest.fixture(scope="module")

--- a/samples/snippets/quickstart_test.py
+++ b/samples/snippets/quickstart_test.py
@@ -64,8 +64,8 @@ def subscription_path(client):
     yield subscription_path
     try:
         client.delete_subscription(subscription_path)
-    except NotFound:
-        pass
+    except (InternalServerError, NotFound) as e:
+        print(e)
 
 
 def test_create_lite_topic_example(topic_path, capsys):


### PR DESCRIPTION
Fixes #148.

This is actually a bug in the library. See #152 