### PR TITLE
fix: is_reset_signal should handle status that is None

### DIFF
--- a/google/cloud/pubsublite/internal/wire/reset_signal.py
+++ b/google/cloud/pubsublite/internal/wire/reset_signal.py
@@ -29,14 +29,17 @@ def is_reset_signal(error: GoogleAPICallError) -> bool:
         return False
     try:
         status = rpc_status.from_call(error.response)
+        if not status:
+            return False
         for detail in status.details:
-            info = ErrorInfo()
-            if (
-                detail.Unpack(info)
-                and info.reason == "RESET"
-                and info.domain == "pubsublite.googleapis.com"
-            ):
-                return True
+            if detail.Is(ErrorInfo.DESCRIPTOR):
+                info = ErrorInfo()
+                if (
+                    detail.Unpack(info)
+                    and info.reason == "RESET"
+                    and info.domain == "pubsublite.googleapis.com"
+                ):
+                    return True
     except ValueError:
         pass
     return False

--- a/google/cloud/pubsublite/testing/test_reset_signal.py
+++ b/google/cloud/pubsublite/testing/test_reset_signal.py
@@ -30,6 +30,13 @@ def make_call(status_pb: Status) -> grpc.Call:
     return mock_call
 
 
+def make_call_without_metadata(status_pb: Status) -> grpc.Call:
+    mock_call = make_call(status_pb)
+    # Causes rpc_status.from_call to return None.
+    mock_call.trailing_metadata.return_value = None
+    return mock_call
+
+
 def make_reset_signal() -> GoogleAPICallError:
     any = Any()
     any.Pack(ErrorInfo(reason="RESET", domain="pubsublite.googleapis.com"))

--- a/tests/unit/pubsublite/internal/wire/reset_signal_test.py
+++ b/tests/unit/pubsublite/internal/wire/reset_signal_test.py
@@ -17,6 +17,7 @@ from google.api_core.exceptions import Aborted, NotFound
 from google.cloud.pubsublite.internal.wire.reset_signal import is_reset_signal
 from google.cloud.pubsublite.testing.test_reset_signal import (
     make_call,
+    make_call_without_metadata,
     make_reset_signal,
 )
 from google.protobuf.any_pb2 import Any
@@ -37,6 +38,13 @@ async def test_non_retryable():
 
 async def test_missing_call():
     assert not is_reset_signal(Aborted(""))
+
+
+async def test_extracted_status_is_none():
+    status_pb = Status(code=10, details=[])
+    assert not is_reset_signal(
+        Aborted("", response=make_call_without_metadata(status_pb))
+    )
 
 
 async def test_wrong_reason():


### PR DESCRIPTION
When [trailing_metadata is None](https://github.com/grpc/grpc/blob/6730d93a3ac1f9bbfb6cef57fe12718779db352c/src/python/grpcio_status/grpc_status/rpc_status.py#L47), `rpc_status.from_call()` returns None. This needs to be handled when detecting the `RESET` signal.