### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Python Client for Pub/Sub Lite
 - `Product Documentation`_
 
 .. |GA| image:: https://img.shields.io/badge/support-ga-gold.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-pubsublite.svg
    :target: https://pypi.org/project/google-cloud-pubsublite/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-pubsublite.svg
@@ -79,4 +79,4 @@ Next Steps
    APIs that we cover.
 
 .. _Pub/Sub Lite API Product documentation:  https://cloud.google.com/pubsub/lite
-.. _README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.