### PR TITLE
fix: performance issues with subscriber client

### DIFF
--- a/google/cloud/pubsublite/cloudpubsub/internal/single_subscriber.py
+++ b/google/cloud/pubsublite/cloudpubsub/internal/single_subscriber.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from abc import abstractmethod, ABCMeta
-from typing import AsyncContextManager, Callable, Set, Optional
+from typing import AsyncContextManager, Callable, List, Set, Optional
 
 from google.cloud.pubsub_v1.subscriber.message import Message
 
@@ -32,12 +32,13 @@ class AsyncSingleSubscriber(AsyncContextManager, metaclass=ABCMeta):
     """
 
     @abstractmethod
-    async def read(self) -> Message:
+    async def read(self) -> List[Message]:
         """
-        Read the next message off of the stream.
+        Read the next batch off of the stream.
 
         Returns:
-          The next message. ack() or nack() must eventually be called exactly once.
+          The next batch of messages. ack() or nack() must eventually be called
+          exactly once on each message.
 
           Pub/Sub Lite does not support nack() by default- if you do call nack(), it will immediately fail the client
           unless you have a NackHandler installed.

--- a/google/cloud/pubsublite/cloudpubsub/internal/subscriber_impl.py
+++ b/google/cloud/pubsublite/cloudpubsub/internal/subscriber_impl.py
@@ -84,8 +84,8 @@ class SubscriberImpl(ContextManager, StreamingPullManager):
     async def _poller(self):
         try:
             while True:
-                message = await self._underlying.read()
-                self._unowned_executor.submit(self._callback, message)
+                batch = await self._underlying.read()
+                self._unowned_executor.map(self._callback, batch)
         except GoogleAPICallError as e:  # noqa: F841  Flake8 thinks e is unused
             self._unowned_executor.submit(lambda: self._fail(e))  # noqa: F821
 

--- a/google/cloud/pubsublite/internal/fast_serialize.py
+++ b/google/cloud/pubsublite/internal/fast_serialize.py
@@ -1,0 +1,13 @@
+"""
+A fast serialization method for lists of integers.
+"""
+
+from typing import List
+
+
+def dump(data: List[int]) -> str:
+    return ",".join(str(x) for x in data)
+
+
+def load(source: str) -> List[int]:
+    return [int(x) for x in source.split(",")]

--- a/google/cloud/pubsublite/internal/wire/permanent_failable.py
+++ b/google/cloud/pubsublite/internal/wire/permanent_failable.py
@@ -15,11 +15,17 @@
 import asyncio
 from typing import Awaitable, TypeVar, Optional, Callable
 
-from google.api_core.exceptions import GoogleAPICallError
+from google.api_core.exceptions import GoogleAPICallError, Unknown
 
 from google.cloud.pubsublite.internal.wait_ignore_cancelled import wait_ignore_errors
 
 T = TypeVar("T")
+
+
+def adapt_error(e: Exception) -> GoogleAPICallError:
+    if isinstance(e, GoogleAPICallError):
+        return e
+    return Unknown("Had an unknown error", errors=[e])
 
 
 class _TaskWithCleanup:

--- a/google/cloud/pubsublite/internal/wire/subscriber.py
+++ b/google/cloud/pubsublite/internal/wire/subscriber.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from abc import abstractmethod, ABCMeta
-from typing import AsyncContextManager
+from typing import AsyncContextManager, List
 from google.cloud.pubsublite_v1.types import SequencedMessage, FlowControlRequest
 
 
@@ -23,12 +23,12 @@ class Subscriber(AsyncContextManager, metaclass=ABCMeta):
     """
 
     @abstractmethod
-    async def read(self) -> SequencedMessage:
+    async def read(self) -> List[SequencedMessage.meta.pb]:
         """
-        Read the next message off of the stream.
+        Read a batch of messages off of the stream.
 
         Returns:
-          The next message.
+          The next batch of messages.
 
         Raises:
           GoogleAPICallError: On a permanent error.

--- a/noxfile.py
+++ b/noxfile.py
@@ -112,6 +112,7 @@ def default(session):
         "--cov-config=.coveragerc",
         "--cov-report=",
         "--cov-fail-under=0",
+        "-v",
         os.path.join("tests", "unit"),
         *session.posargs,
     )

--- a/samples/snippets/subscriber_example.py
+++ b/samples/snippets/subscriber_example.py
@@ -23,10 +23,10 @@ import argparse
 
 from google.cloud.pubsublite.types import MessageMetadata
 from google.pubsub_v1 import PubsubMessage
-from time import sleep
 
 
 def receive_messages(
+    project_number, cloud_region, zone_id, subscription_id, timeout=90
 ):
     # [START pubsublite_quickstart_subscriber]
     from concurrent.futures._base import TimeoutError
@@ -34,7 +34,7 @@ def receive_messages(
     from google.cloud.pubsublite.types import (
         CloudRegion,
         CloudZone,
-        FlowControlSettings, DISABLED_FLOW_CONTROL,
+        FlowControlSettings,
         SubscriptionPath,
     )
 
@@ -45,16 +45,16 @@ def receive_messages(
     # subscription_id = "your-subscription-id"
     # timeout = 90
 
-    # location = CloudZone(CloudRegion(cloud_region), zone_id)
-    subscription_path = SubscriptionPath.parse("projects/129988248131/locations/us-central1-a/subscriptions/dpcollins-test-python-throughput")
+    location = CloudZone(CloudRegion(cloud_region), zone_id)
+    subscription_path = SubscriptionPath(project_number, location, subscription_id)
     # Configure when to pause the message stream for more incoming messages based on the
     # maximum size or number of messages that a single-partition subscriber has received,
     # whichever condition is met first.
     per_partition_flow_control_settings = FlowControlSettings(
         # 1,000 outstanding messages. Must be >0.
-        messages_outstanding=100000000000,
-        # 500 MiB. Must be greater than the allowed size of the largest message (1 MiB).
-        bytes_outstanding=500 * 1024 * 1024,
+        messages_outstanding=1000,
+        # 10 MiB. Must be greater than the allowed size of the largest message (1 MiB).
+        bytes_outstanding=10 * 1024 * 1024,
     )
 
     def callback(message: PubsubMessage):
@@ -65,6 +65,7 @@ def receive_messages(
 
     # SubscriberClient() must be used in a `with` block or have __enter__() called before use.
     with SubscriberClient() as subscriber_client:
+
         streaming_pull_future = subscriber_client.subscribe(
             subscription_path,
             callback=callback,
@@ -74,7 +75,7 @@ def receive_messages(
         print(f"Listening for messages on {str(subscription_path)}...")
 
         try:
-            streaming_pull_future.result(timeout=180)
+            streaming_pull_future.result(timeout=timeout)
         except TimeoutError or KeyboardInterrupt:
             streaming_pull_future.cancel()
             assert streaming_pull_future.done()
@@ -82,7 +83,6 @@ def receive_messages(
 
 
 if __name__ == "__main__":
-    """
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -99,6 +99,11 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
-    """
 
-    receive_messages()
+    receive_messages(
+        args.project_number,
+        args.cloud_region,
+        args.zone_id,
+        args.subscription_id,
+        args.timeout,
+    )

--- a/tests/unit/pubsublite/cloudpubsub/internal/multiplexed_async_subscriber_client_test.py
+++ b/tests/unit/pubsublite/cloudpubsub/internal/multiplexed_async_subscriber_client_test.py
@@ -66,7 +66,8 @@ async def test_iterator(
 ):
     read_queues = wire_queues(default_subscriber.read)
     subscription = SubscriptionPath(1, CloudZone.parse("us-central1-a"), "abc")
-    message = Message(PubsubMessage(message_id="1")._pb, "", 0, None)
+    message1 = Message(PubsubMessage(message_id="1")._pb, "", 0, None)
+    message2 = Message(PubsubMessage(message_id="2")._pb, "", 0, None)
     async with multiplexed_client:
         iterator = await multiplexed_client.subscribe(
             subscription, DISABLED_FLOW_CONTROL
@@ -78,8 +79,9 @@ async def test_iterator(
         assert not read_fut_1.done()
         await read_queues.called.get()
         default_subscriber.read.assert_has_calls([call()])
-        await read_queues.results.put(message)
-        assert await read_fut_1 is message
+        await read_queues.results.put([message1, message2])
+        assert await read_fut_1 is message1
+        assert await iterator.__anext__() is message2
         read_fut_2 = asyncio.ensure_future(iterator.__anext__())
         assert not read_fut_2.done()
         await read_queues.called.get()


### PR DESCRIPTION
The primary change here is to access the raw proto in as many places as possible due to proto-plus-python performance issues.

The secondary change is to reduce the asyncio overhead by propagating batches through more layers of code.