### PR TITLE
fix: Race conditions and performance issues

### DIFF
--- a/google/cloud/pubsublite/cloudpubsub/internal/ack_set_tracker_impl.py
+++ b/google/cloud/pubsublite/cloudpubsub/internal/ack_set_tracker_impl.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import queue
 from collections import deque
 from typing import Optional
 
 from google.api_core.exceptions import FailedPrecondition
 
+from google.cloud.pubsublite.cloudpubsub.internal.sorted_list import SortedList
 from google.cloud.pubsublite.cloudpubsub.internal.ack_set_tracker import AckSetTracker
 from google.cloud.pubsublite.internal.wire.committer import Committer
 from google.cloud.pubsublite_v1 import Cursor
@@ -27,13 +27,13 @@ class AckSetTrackerImpl(AckSetTracker):
     _committer: Committer
 
     _receipts: "deque[int]"
-    _acks: "queue.PriorityQueue[int]"
+    _acks: SortedList[int]
 
     def __init__(self, committer: Committer):
         super().__init__()
         self._committer = committer
         self._receipts = deque()
-        self._acks = queue.PriorityQueue()
+        self._acks = SortedList()
 
     def track(self, offset: int):
         if len(self._receipts) > 0:
@@ -45,25 +45,27 @@ class AckSetTrackerImpl(AckSetTracker):
         self._receipts.append(offset)
 
     def ack(self, offset: int):
-        self._acks.put_nowait(offset)
+        self._acks.push(offset)
         prefix_acked_offset: Optional[int] = None
         while len(self._receipts) != 0 and not self._acks.empty():
             receipt = self._receipts.popleft()
-            ack = self._acks.get_nowait()
+            ack = self._acks.peek()
             if receipt == ack:
                 prefix_acked_offset = receipt
+                self._acks.pop()
                 continue
             self._receipts.appendleft(receipt)
-            self._acks.put(ack)
             break
         if prefix_acked_offset is None:
             return
         # Convert from last acked to first unacked.
-        self._committer.commit(Cursor(offset=prefix_acked_offset + 1))
+        cursor = Cursor()
+        cursor._pb.offset = prefix_acked_offset + 1
+        self._committer.commit(cursor)
 
     async def clear_and_commit(self):
         self._receipts.clear()
-        self._acks = queue.PriorityQueue()
+        self._acks = SortedList()
         await self._committer.wait_until_empty()
 
     async def __aenter__(self):

--- a/google/cloud/pubsublite/cloudpubsub/internal/single_partition_subscriber.py
+++ b/google/cloud/pubsublite/cloudpubsub/internal/single_partition_subscriber.py
@@ -127,12 +127,12 @@ class SinglePartitionSingleSubscriber(
             raise e
 
     def _handle_ack(self, message: requests.AckRequest):
-        self._underlying.allow_flow(
-            FlowControlRequest(
-                allowed_messages=1,
-                allowed_bytes=self._messages_by_ack_id[message.ack_id].size_bytes,
-            )
-        )
+        flow_control = FlowControlRequest()
+        flow_control._pb.allowed_messages = 1
+        flow_control._pb.allowed_bytes = self._messages_by_ack_id[
+            message.ack_id
+        ].size_bytes
+        self._underlying.allow_flow(flow_control)
         del self._messages_by_ack_id[message.ack_id]
         # Always refill flow control tokens, but do not commit offsets from outdated generations.
         ack_id = _AckId.parse(message.ack_id)

--- a/google/cloud/pubsublite/cloudpubsub/internal/sorted_list.py
+++ b/google/cloud/pubsublite/cloudpubsub/internal/sorted_list.py
@@ -1,0 +1,25 @@
+from typing import Generic, TypeVar, List, Optional
+import heapq
+
+_T = TypeVar("_T")
+
+
+class SortedList(Generic[_T]):
+    _vals: List[_T]
+
+    def __init__(self):
+        self._vals = []
+
+    def push(self, val: _T):
+        heapq.heappush(self._vals, val)
+
+    def peek(self) -> Optional[_T]:
+        if self.empty():
+            return None
+        return self._vals[0]
+
+    def pop(self):
+        heapq.heappop(self._vals)
+
+    def empty(self) -> bool:
+        return not bool(self._vals)

--- a/google/cloud/pubsublite/internal/wire/assigner_impl.py
+++ b/google/cloud/pubsublite/internal/wire/assigner_impl.py
@@ -17,6 +17,8 @@ from typing import Optional, Set
 
 import logging
 
+from overrides import overrides
+
 from google.cloud.pubsublite.internal.wait_ignore_cancelled import wait_ignore_errors
 from google.cloud.pubsublite.internal.wire.assigner import Assigner
 from google.cloud.pubsublite.internal.wire.retrying_connection import (
@@ -103,15 +105,17 @@ class AssignerImpl(
         await self._stop_receiver()
         await self._connection.__aexit__(exc_type, exc_val, exc_tb)
 
-    async def reinitialize(
-        self,
-        connection: Connection[PartitionAssignmentRequest, PartitionAssignment],
-        last_error: Optional[GoogleAPICallError],
-    ):
+    @overrides
+    async def stop_processing(self, error: GoogleAPICallError):
+        await self._stop_receiver()
         self._outstanding_assignment = False
         while not self._new_assignment.empty():
             self._new_assignment.get_nowait()
-        await self._stop_receiver()
+
+    @overrides
+    async def reinitialize(
+        self, connection: Connection[PartitionAssignmentRequest, PartitionAssignment],
+    ):
         await connection.write(PartitionAssignmentRequest(initial=self._initial))
         self._start_receiver()
 

--- a/google/cloud/pubsublite/internal/wire/connection_reinitializer.py
+++ b/google/cloud/pubsublite/internal/wire/connection_reinitializer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Generic, Optional
+from typing import Generic
 from abc import ABCMeta, abstractmethod
 from google.api_core.exceptions import GoogleAPICallError
 from google.cloud.pubsublite.internal.wire.connection import (
@@ -26,17 +26,24 @@ class ConnectionReinitializer(Generic[Request, Response], metaclass=ABCMeta):
     """A class capable of reinitializing a connection after a new one has been created."""
 
     @abstractmethod
-    def reinitialize(
-        self,
-        connection: Connection[Request, Response],
-        last_error: Optional[GoogleAPICallError],
+    async def stop_processing(self, error: GoogleAPICallError):
+        """Tear down internal state processing the current connection in
+        response to a stream error.
+
+        Args:
+            error: The error that caused the stream to break
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    async def reinitialize(
+        self, connection: Connection[Request, Response],
     ):
         """Reinitialize a connection. Must ensure no calls to the associated RetryingConnection
         occur until this completes.
 
         Args:
             connection: The connection to reinitialize
-            last_error: The last error that caused the stream to break
 
         Raises:
             GoogleAPICallError: If it fails to reinitialize.

--- a/google/cloud/pubsublite/internal/wire/retrying_connection.py
+++ b/google/cloud/pubsublite/internal/wire/retrying_connection.py
@@ -88,7 +88,7 @@ class RetryingConnection(Connection[Request, Response], PermanentFailable):
         """
         try:
             bad_retries = 0
-            while True:
+            while not self.error():
                 try:
                     conn_fut = self._connection_factory.new()
                     async with (await conn_fut) as connection:

--- a/google/cloud/pubsublite/internal/wire/single_partition_publisher.py
+++ b/google/cloud/pubsublite/internal/wire/single_partition_publisher.py
@@ -169,12 +169,14 @@ class SinglePartitionPublisher(
             await self._flush()
         return MessageMetadata(self._partition, await future)
 
-    async def reinitialize(
-        self,
-        connection: Connection[PublishRequest, PublishResponse],
-        last_error: Optional[GoogleAPICallError],
-    ):
+    @overrides
+    async def stop_processing(self, error: GoogleAPICallError):
         await self._stop_loopers()
+
+    @overrides
+    async def reinitialize(
+        self, connection: Connection[PublishRequest, PublishResponse],
+    ):
         await connection.write(PublishRequest(initial_request=self._initial))
         response = await connection.read()
         if "initial_response" not in response:


### PR DESCRIPTION
There are two main retrying_connection race conditions fixed here:

1) Improper handling of cancelled write tasks can cause set_exception to be called when the task is already cancelled, which raises an InvalidStateError which is never caught by the existing code.
2) There is a race where if reinitialize() is called after queues are cycled, meaning a poller from the old instance of the class can add a message to the new queues. This has been fixed by splitting the ConnectionReinitializer interface into "stop_processing" and "reinitialize" parts.

Also fix other performance issues identified in profiles.

Something close to this code has been running for an hour or two on compute engine with no hangs.