### PR TITLE
feat: Add ReassignmentHandler which is notified on client reassignment

### DIFF
--- a/google/cloud/pubsublite/cloudpubsub/internal/make_subscriber.py
+++ b/google/cloud/pubsublite/cloudpubsub/internal/make_subscriber.py
@@ -18,6 +18,10 @@ from uuid import uuid4
 from google.api_core.client_options import ClientOptions
 from google.auth.credentials import Credentials
 
+from google.cloud.pubsublite.cloudpubsub.reassignment_handler import (
+    ReassignmentHandler,
+    DefaultReassignmentHandler,
+)
 from google.cloud.pubsublite.cloudpubsub.message_transforms import (
     to_cps_subscribe_message,
     add_id_to_cps_subscribe_transformer,
@@ -179,6 +183,7 @@ def make_async_subscriber(
     transport: str,
     per_partition_flow_control_settings: FlowControlSettings,
     nack_handler: Optional[NackHandler] = None,
+    reassignment_handler: Optional[ReassignmentHandler] = None,
     message_transformer: Optional[MessageTransformer] = None,
     fixed_partitions: Optional[Set[Partition]] = None,
     credentials: Optional[Credentials] = None,
@@ -218,6 +223,8 @@ def make_async_subscriber(
 
     if nack_handler is None:
         nack_handler = DefaultNackHandler()
+    if reassignment_handler is None:
+        reassignment_handler = DefaultReassignmentHandler()
     if message_transformer is None:
         message_transformer = MessageTransformer.of_callable(to_cps_subscribe_message)
     partition_subscriber_factory = _make_partition_subscriber_factory(

--- a/google/cloud/pubsublite/cloudpubsub/internal/make_subscriber.py
+++ b/google/cloud/pubsublite/cloudpubsub/internal/make_subscriber.py
@@ -237,4 +237,6 @@ def make_async_subscriber(
         nack_handler,
         message_transformer,
     )
-    return AssigningSingleSubscriber(assigner_factory, partition_subscriber_factory)
+    return AssigningSingleSubscriber(
+        assigner_factory, partition_subscriber_factory, reassignment_handler
+    )

--- a/google/cloud/pubsublite/cloudpubsub/nack_handler.py
+++ b/google/cloud/pubsublite/cloudpubsub/nack_handler.py
@@ -28,6 +28,8 @@ class NackHandler(ABC):
     def on_nack(self, message: PubsubMessage, ack: Callable[[], None]):
         """Handle a negative acknowledgement. ack must eventually be called.
 
+        This method will be called on an event loop and should not block.
+
         Args:
           message: The nacked message.
           ack: A callable to acknowledge the underlying message. This must eventually be called.

--- a/google/cloud/pubsublite/cloudpubsub/publisher_client.py
+++ b/google/cloud/pubsublite/cloudpubsub/publisher_client.py
@@ -62,6 +62,7 @@ class PublisherClient(PublisherClientInterface, ConstructableFromServiceAccount)
 
     def __init__(
         self,
+        *,
         per_partition_batching_settings: Optional[BatchSettings] = None,
         credentials: Optional[Credentials] = None,
         transport: str = "grpc_asyncio",
@@ -93,7 +94,7 @@ class PublisherClient(PublisherClientInterface, ConstructableFromServiceAccount)
         topic: Union[TopicPath, str],
         data: bytes,
         ordering_key: str = "",
-        **attrs: Mapping[str, str]
+        **attrs: Mapping[str, str],
     ) -> "Future[str]":
         self._require_stared.require_started()
         return self._impl.publish(
@@ -132,6 +133,7 @@ class AsyncPublisherClient(
 
     def __init__(
         self,
+        *,
         per_partition_batching_settings: Optional[BatchSettings] = None,
         credentials: Optional[Credentials] = None,
         transport: str = "grpc_asyncio",
@@ -163,7 +165,7 @@ class AsyncPublisherClient(
         topic: Union[TopicPath, str],
         data: bytes,
         ordering_key: str = "",
-        **attrs: Mapping[str, str]
+        **attrs: Mapping[str, str],
     ) -> str:
         self._require_stared.require_started()
         return await self._impl.publish(

--- a/google/cloud/pubsublite/cloudpubsub/reassignment_handler.py
+++ b/google/cloud/pubsublite/cloudpubsub/reassignment_handler.py
@@ -30,7 +30,7 @@ class ReassignmentHandler(ABC):
 
     Because of the above, as long as reassignment handling is processed quickly, it can be used to
     abort outstanding operations on partitions which are being assigned away from this client, or to
-    pre-warm state which will be used by the subscriber handler.
+    pre-warm state which will be used by the MessageCallback.
     """
 
     @abstractmethod
@@ -43,9 +43,10 @@ class ReassignmentHandler(ABC):
         quickly, or the backend will assume it is non-responsive and assign all partitions away without
         waiting for acknowledgement.
 
-        If this method returns an awaitable, it will be awaited before acknowledging the assignment.
+        handle_reassignment will only be called after no new message deliveries will be started for the partition.
+        There may still be messages in flight on executors or in async callbacks.
 
-        Nacks on messages for partitions being assigned away will not call the client's nackHandler.
+        Acks or nacks on messages from partitions being assigned away will have no effect.
 
         This method will be called on an event loop and should not block.
 

--- a/google/cloud/pubsublite/cloudpubsub/reassignment_handler.py
+++ b/google/cloud/pubsublite/cloudpubsub/reassignment_handler.py
@@ -1,0 +1,69 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+from typing import Set, Optional, Awaitable
+
+from google.cloud.pubsublite.types import Partition
+
+
+class ReassignmentHandler(ABC):
+    """
+    A ReassignmentHandler is called any time a new partition assignment is received from the server.
+    It will be called with both the previous and new assignments as decided by the backend.
+
+    The client library will not acknowledge the assignment until handleReassignment returns. The
+    assigning backend will not assign any of the partitions in `before` to another server unless the
+    assignment is acknowledged, or a client takes too long to acknowledged (currently 30 seconds from
+    the time the assignment is sent from server's point of view).
+
+    Because of the above, as long as reassignment handling is processed quickly, it can be used to
+    abort outstanding operations on partitions which are being assigned away from this client, or to
+    pre-warm state which will be used by the subscriber handler.
+    """
+
+    @abstractmethod
+    def handle_reassignment(
+        self, before: Set[Partition], after: Set[Partition]
+    ) -> Optional[Awaitable]:
+        """
+        Called with the previous and new assignment delivered to this client on an assignment change.
+        The assignment will not be acknowledged until this method returns, so it should complete
+        quickly, or the backend will assume it is non-responsive and assign all partitions away without
+        waiting for acknowledgement.
+
+        If this method returns an awaitable, it will be awaited before acknowledging the assignment.
+
+        Nacks on messages for partitions being assigned away will not call the client's nackHandler.
+
+        This method will be called on an event loop and should not block.
+
+        Args:
+          before: The previous assignment.
+          after: The new assignment.
+
+        Returns:
+          Either None or an Awaitable to be waited on before acknowledging reassignment.
+
+        Raises:
+          GoogleAPICallError: To fail the client if raised.
+        """
+        pass
+
+
+class DefaultReassignmentHandler(ReassignmentHandler):
+    def handle_reassignment(
+        self, before: Set[Partition], after: Set[Partition]
+    ) -> Optional[Awaitable]:
+        return None

--- a/google/cloud/pubsublite/cloudpubsub/subscriber_client.py
+++ b/google/cloud/pubsublite/cloudpubsub/subscriber_client.py
@@ -20,6 +20,7 @@ from google.auth.credentials import Credentials
 from google.cloud.pubsub_v1.subscriber.futures import StreamingPullFuture
 from google.cloud.pubsub_v1.subscriber.message import Message
 
+from google.cloud.pubsublite.cloudpubsub.reassignment_handler import ReassignmentHandler
 from google.cloud.pubsublite.cloudpubsub.internal.make_subscriber import (
     make_async_subscriber,
 )
@@ -61,8 +62,10 @@ class SubscriberClient(SubscriberClientInterface, ConstructableFromServiceAccoun
 
     def __init__(
         self,
+        *,
         executor: Optional[ThreadPoolExecutor] = None,
         nack_handler: Optional[NackHandler] = None,
+        reassignment_handler: Optional[ReassignmentHandler] = None,
         message_transformer: Optional[MessageTransformer] = None,
         credentials: Optional[Credentials] = None,
         transport: str = "grpc_asyncio",
@@ -88,6 +91,7 @@ class SubscriberClient(SubscriberClientInterface, ConstructableFromServiceAccoun
                 transport=transport,
                 per_partition_flow_control_settings=settings,
                 nack_handler=nack_handler,
+                reassignment_handler=reassignment_handler,
                 message_transformer=message_transformer,
                 fixed_partitions=partitions,
                 credentials=credentials,
@@ -140,7 +144,9 @@ class AsyncSubscriberClient(
 
     def __init__(
         self,
+        *,
         nack_handler: Optional[NackHandler] = None,
+        reassignment_handler: Optional[ReassignmentHandler] = None,
         message_transformer: Optional[MessageTransformer] = None,
         credentials: Optional[Credentials] = None,
         transport: str = "grpc_asyncio",
@@ -162,6 +168,7 @@ class AsyncSubscriberClient(
                 transport=transport,
                 per_partition_flow_control_settings=settings,
                 nack_handler=nack_handler,
+                reassignment_handler=reassignment_handler,
                 message_transformer=message_transformer,
                 fixed_partitions=partitions,
                 credentials=credentials,

--- a/google/cloud/pubsublite/internal/wire/permanent_failable.py
+++ b/google/cloud/pubsublite/internal/wire/permanent_failable.py
@@ -85,8 +85,10 @@ class PermanentFailable:
         try:
             while True:
                 await self.await_unless_failed(poll_action())
-        except GoogleAPICallError as e:
-            self.fail(e)
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            self.fail(adapt_error(e))
 
     def fail(self, err: GoogleAPICallError):
         if not self._failure_task.done():


### PR DESCRIPTION
This enables clients to respond to a reassignment by cancelling outstanding actions and nacking all messages.
