### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -9,6 +9,7 @@
     "library_type": "GAPIC_COMBO",
     "repo": "googleapis/python-pubsublite",
     "distribution_name": "google-cloud-pubsublite",
-    "api_id": "pubsublite.googleapis.com"
-  }
-  
+    "api_id": "pubsublite.googleapis.com",
+    "default_version": "",
+    "codeowner_team": ""
+}


### PR DESCRIPTION
set `codeowner_team` to `googleapis/api-pubsublite`. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114
