### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "pubsublite",
     "name_pretty": "Pub/Sub Lite",
     "product_documentation": "https://https://cloud.google.com/pubsub/lite",
-    "client_documentation": "https://googleapis.dev/python/pubsublite/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/pubsublite/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for Pub/Sub Lite
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-pubsublite.svg
    :target: https://pypi.org/project/google-cloud-pubsublite/
 .. _Pub/Sub Lite API: https://cloud.google.com/pubsub/lite
-.. _Client Library Documentation: https://googleapis.dev/python/pubsublite/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/pubsublite/latest
 .. _Product Documentation:  https://cloud.google.com/pubsub/lite
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.