### PR TITLE
chore: make samples 3.6 check optional

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -30,7 +30,6 @@ branchProtectionRules:
   requiredStatusCheckContexts:
     - 'Kokoro'
     - 'cla/google'
-    - 'Samples - Python 3.6'
     - 'Samples - Python 3.7'
     - 'Samples - Python 3.8'
     - 'Samples - Lint'


### PR DESCRIPTION
3.6 went end-of-life in December.