### PR TITLE
samples: add reservation samples

### DIFF
--- a/samples/snippets/create_lite_reservation_example.py
+++ b/samples/snippets/create_lite_reservation_example.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2022 Google Inc. All Rights Reserved.
+# Copyright 2022 Google LLC. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/snippets/create_lite_reservation_example.py
+++ b/samples/snippets/create_lite_reservation_example.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+# Copyright 2022 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This application demonstrates how to create a reservation using the
+Pub/Sub Lite API. For more information, see the root level README.md and
+the documentation at https://cloud.google.com/pubsub/lite/docs/reservations.
+"""
+
+import argparse
+
+
+def create_lite_reservation(
+    project_number, cloud_region, reservation_id, throughput_capacity,
+):
+    # [START pubsublite_create_reservation]
+    from google.api_core.exceptions import AlreadyExists
+    from google.cloud.pubsublite import AdminClient, Reservation
+    from google.cloud.pubsublite.types import CloudRegion, ReservationPath
+
+    # TODO(developer):
+    # project_number = 1122334455
+    # cloud_region = "us-central1"
+    # reservation_id = "your-reservation-id"
+    # Each unit of throughput capacity supports up to 1 MiB/s of published messages
+    # or 2 MiB/s of subscribed messages. Must be a positive integer.
+    # throughput_capacity = 4
+
+    cloud_region = CloudRegion(cloud_region)
+    reservation_path = ReservationPath(project_number, cloud_region, reservation_id)
+
+    reservation = Reservation(
+        name=str(reservation_path), throughput_capacity=throughput_capacity,
+    )
+
+    client = AdminClient(cloud_region)
+    try:
+        response = client.create_reservation(reservation)
+        print(f"{response.name} created successfully.")
+    except AlreadyExists:
+        print(f"{reservation_path} already exists.")
+    # [END pubsublite_create_reservation]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("project_number", help="Your Google Cloud Project Number")
+    parser.add_argument("cloud_region", help="Your Cloud Region, e.g. 'us-central1'")
+    parser.add_argument("reservation_id", help="Your reservation ID")
+    parser.add_argument(
+        "throughput_capacity",
+        type=int,
+        help="Each unit of throughput capacity supports up to 1 MiB/s of published messages or 2 MiB/s of subscribed messages. Must be a positive integer.",
+    )
+
+    args = parser.parse_args()
+
+    create_lite_reservation(
+        args.project_number,
+        args.cloud_region,
+        args.reservation_id,
+        args.throughput_capacity,
+    )

--- a/samples/snippets/delete_lite_reservation_example.py
+++ b/samples/snippets/delete_lite_reservation_example.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2022 Google Inc. All Rights Reserved.
+# Copyright 2022 Google LLC. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/snippets/delete_lite_reservation_example.py
+++ b/samples/snippets/delete_lite_reservation_example.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+# Copyright 2022 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This application demonstrates how to delete a reservation using
+the Pub/Sub Lite API. For more information, see the root level README.md
+and the documentation at https://cloud.google.com/pubsub/lite/docs/topics.
+"""
+
+import argparse
+
+
+def delete_lite_reservation(project_number, cloud_region, reservation_id):
+    # [START pubsublite_delete_reservation]
+    from google.api_core.exceptions import NotFound
+    from google.cloud.pubsublite import AdminClient
+    from google.cloud.pubsublite.types import CloudRegion, ReservationPath
+
+    # TODO(developer):
+    # project_number = 1122334455
+    # cloud_region = "us-central1"
+    # reservation_id = "your-reservation-id"
+
+    cloud_region = CloudRegion(cloud_region)
+    reservation_path = ReservationPath(project_number, cloud_region, reservation_id)
+
+    client = AdminClient(cloud_region)
+    try:
+        client.delete_reservation(reservation_path)
+        print(f"{reservation_path} deleted successfully.")
+    except NotFound:
+        print(f"{reservation_path} not found.")
+    # [END pubsublite_delete_reservation]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("project_number", help="Your Google Cloud Project Number")
+    parser.add_argument("cloud_region", help="Your Cloud Region, e.g. 'us-central1'")
+    parser.add_argument("reservation_id", help="Your reservation ID")
+
+    args = parser.parse_args()
+
+    delete_lite_reservation(
+        args.project_number,
+        args.cloud_region,
+        args.zone_id,
+        args.topic_id,
+        args.regional,
+    )

--- a/samples/snippets/get_lite_reservation_example.py
+++ b/samples/snippets/get_lite_reservation_example.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2022 Google Inc. All Rights Reserved.
+# Copyright 2022 Google LLC. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/snippets/get_lite_reservation_example.py
+++ b/samples/snippets/get_lite_reservation_example.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+# Copyright 2022 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This application demonstrates how to get a reservation using the
+Pub/Sub Lite API. For more information, see the root level README.md and
+the documentation at https://cloud.google.com/pubsub/lite/docs/reservations.
+"""
+
+import argparse
+
+
+def get_lite_reservation(project_number, cloud_region, reservation_id):
+    # [START pubsublite_get_reservation]
+    from google.api_core.exceptions import NotFound
+    from google.cloud.pubsublite import AdminClient
+    from google.cloud.pubsublite.types import CloudRegion, ReservationPath
+
+    # TODO(developer):
+    # project_number = 1122334455
+    # cloud_region = "us-central1"
+    # reservation_id = "your-reservation-id"
+
+    cloud_region = CloudRegion(cloud_region)
+    reservation_path = ReservationPath(project_number, cloud_region, reservation_id)
+
+    client = AdminClient(cloud_region)
+    try:
+        response = client.get_reservation(reservation_path)
+        print(
+            f"{response.name} has {response.throughput_capacity} units of throughput capacity."
+        )
+    except NotFound:
+        print(f"{reservation_path} is not found.")
+    # [END pubsublite_get_reservation]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("project_number", help="Your Google Cloud Project Number")
+    parser.add_argument("cloud_region", help="Your Cloud Region, e.g. 'us-central1'")
+    parser.add_argument("reservation_id", help="Your reservation ID")
+
+    args = parser.parse_args()
+
+    get_lite_reservation(
+        args.project_number, args.cloud_region, args.reservation_id,
+    )

--- a/samples/snippets/list_lite_reservations_example.py
+++ b/samples/snippets/list_lite_reservations_example.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2022 Google Inc. All Rights Reserved.
+# Copyright 2022 Google LLC. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/snippets/list_lite_reservations_example.py
+++ b/samples/snippets/list_lite_reservations_example.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+# Copyright 2022 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This application demonstrates how to list reservations using the Pub/Sub
+Lite API. For more information, see the root level README.md and the
+documentation at https://cloud.google.com/pubsub/lite/docs/topics.
+"""
+
+import argparse
+
+
+def list_lite_reservations(project_number, cloud_region):
+    # [START pubsublite_list_reservations]
+    from google.cloud.pubsublite import AdminClient
+    from google.cloud.pubsublite.types import LocationPath
+
+    # TODO(developer):
+    # project_number = 1122334455
+    # cloud_region = "us-central1"
+
+    location_path = LocationPath(project_number, cloud_region)
+
+    client = AdminClient(cloud_region)
+    response = client.list_reservations(location_path)
+
+    for reservation in response:
+        print(reservation)
+
+    print(f"{len(response)} reservation(s) listed in your project and location.")
+    # [END pubsublite_list_reservations]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("project_number", help="Your Google Cloud Project Number")
+    parser.add_argument("cloud_region", help="Your Cloud Region, e.g. 'us-central1'")
+
+    args = parser.parse_args()
+
+    list_lite_reservations(args.project_number, args.cloud_region)

--- a/samples/snippets/quickstart_test.py
+++ b/samples/snippets/quickstart_test.py
@@ -173,6 +173,56 @@ def subscription(client, zonal_topic):
         print(f"Subscription {response.name} has been cleaned up.")
 
 
+def test_create_lite_reservation_example(capsys):
+    import create_lite_reservation_example
+
+    create_lite_reservation_example.create_lite_reservation(
+        PROJECT_NUMBER, CLOUD_REGION, RESERVATION_ID, 4,
+    )
+
+    wanted_reservation_path = f"projects/{PROJECT_NUMBER}/locations/{CLOUD_REGION}/reservations/{RESERVATION_ID}"
+    out, _ = capsys.readouterr()
+    assert f"{wanted_reservation_path} created successfully." in out
+
+
+def test_update_lite_reservation_example(reservation, capsys):
+    import update_lite_reservation_example
+
+    update_lite_reservation_example.update_lite_reservation(
+        PROJECT_NUMBER, CLOUD_REGION, RESERVATION_ID, 8,
+    )
+
+    reservation_path_object = ReservationPath.parse(reservation.name)
+    out, _ = capsys.readouterr()
+    assert f"{reservation_path_object.name}" in out
+    assert "throughput_capacity: 8" in out
+
+
+def test_get_lite_reservation_example(reservation, capsys):
+    import get_lite_reservation_example
+
+    get_lite_reservation_example.get_lite_reservation(
+        PROJECT_NUMBER, CLOUD_REGION, RESERVATION_ID,
+    )
+
+    reservation_path_object = ReservationPath.parse(reservation.name)
+    out, _ = capsys.readouterr()
+    assert f"{reservation_path_object.name} has 8 units of throughput capacity." in out
+
+
+def test_list_reservations_example(reservation, capsys):
+    import list_lite_reservations_example
+
+    list_lite_reservations_example.list_lite_reservations(
+        PROJECT_NUMBER, CLOUD_REGION,
+    )
+
+    reservation_path_object = ReservationPath.parse(reservation.name)
+    out, _ = capsys.readouterr()
+    assert f"{reservation_path_object.name}" in out
+    assert "reservation(s) listed in your project and location." in out
+
+
 def test_create_lite_topic_example(reservation, capsys):
     import create_lite_topic_example
 
@@ -437,3 +487,17 @@ def test_delete_lite_topic_example(regional_topic, zonal_topic, capsys):
         )
 
     eventually_consistent_test()
+
+
+def test_delete_lite_reservation_example(reservation, capsys):
+    import delete_lite_reservation_example
+
+    reservation_path_object = ReservationPath.parse(reservation.name)
+
+    @backoff.on_exception(backoff.expo, AssertionError, max_time=MAX_TIME)
+    def eventually_consistent_test():
+        delete_lite_reservation_example.delete_lite_reservation(
+            PROJECT_NUMBER, CLOUD_REGION, RESERVATION_ID,
+        )
+        out, _ = capsys.readouterr()
+        assert f"{reservation_path_object.name} deleted successfully." in out

--- a/samples/snippets/update_lite_reservation_example.py
+++ b/samples/snippets/update_lite_reservation_example.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2022 Google Inc. All Rights Reserved.
+# Copyright 2022 Google LLC. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/samples/snippets/update_lite_reservation_example.py
+++ b/samples/snippets/update_lite_reservation_example.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+
+# Copyright 2022 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This application demonstrates how to update a reservation using the
+Pub/Sub Lite API. For more information, see the root level README.md and
+the documentation at https://cloud.google.com/pubsub/lite/docs/reservations.
+"""
+
+import argparse
+
+
+def update_lite_reservation(
+    project_number, cloud_region, reservation_id, throughput_capacity,
+):
+    # [START pubsublite_update_reservation]
+    from google.api_core.exceptions import NotFound
+    from google.cloud.pubsublite import AdminClient, Reservation
+    from google.cloud.pubsublite.types import CloudRegion, ReservationPath
+    from google.protobuf.field_mask_pb2 import FieldMask
+
+    # TODO(developer):
+    # project_number = 1122334455
+    # cloud_region = "us-central1"
+    # reservation_id = "your-reservation-id"
+    # Each unit of throughput capacity supports up to 1 MiB/s of published messages
+    # or 2 MiB/s of subscribed messages. Must be a positive integer.
+    # throughput_capacity = 8
+
+    cloud_region = CloudRegion(cloud_region)
+    reservation_path = ReservationPath(project_number, cloud_region, reservation_id)
+
+    # Defines which fields to update in the reservation.
+    field_mask = FieldMask(paths=["throughput_capacity"])
+
+    reservation = Reservation(
+        name=str(reservation_path), throughput_capacity=throughput_capacity
+    )
+
+    client = AdminClient(cloud_region)
+    try:
+        response = client.get_reservation(reservation_path)
+        print(f"Before update: {response}")
+
+        response = client.update_reservation(reservation, field_mask)
+        print(f"After update: {response}")
+    except NotFound:
+        print(f"{reservation_path} is not found.")
+    # [END pubsublite_update_reservation]
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("project_number", help="Your Google Cloud Project Number")
+    parser.add_argument("cloud_region", help="Your Cloud Region, e.g. 'us-central1'")
+    parser.add_argument("reservation_id", help="Your reservation ID")
+    parser.add_argument(
+        "throughput_capacity",
+        type=int,
+        help="Each unit of throughput capacity supports up to 1 MiB/s of published messages or 2 MiB/s of subscribed messages. Must be a positive integer.",
+    )
+
+    args = parser.parse_args()
+
+    update_lite_reservation(
+        args.project_number,
+        args.cloud_region,
+        args.reservation_id,
+        args.throughput_capacity,
+    )


### PR DESCRIPTION
Towards b/213558019
Adding Python samples for the following region tags:

- `pubsublite_create_reservation`
- `pubsublite_get_reservation`
- `pubsublite_update_reservation`
- `pubsublite_list_reservations`
- `pubsublite_delete_reservation`

Java already added in https://github.com/googleapis/java-pubsublite/pull/1028