### PR TITLE
fix: ensure that _failure_task exception is always retrieved

### DIFF
--- a/google/cloud/pubsublite/internal/wire/permanent_failable.py
+++ b/google/cloud/pubsublite/internal/wire/permanent_failable.py
@@ -93,6 +93,9 @@ class PermanentFailable:
     def fail(self, err: GoogleAPICallError):
         if not self._failure_task.done():
             self._failure_task.set_exception(err)
+            # Ensure that even if _failure_task is never used, the exception is
+            # retrieved and the asyncio runtime doesn't print an error.
+            self._failure_task.exception()
 
     def error(self) -> Optional[GoogleAPICallError]:
         if not self._failure_task.done():


### PR DESCRIPTION
Fixes #285
