### PR TITLE
feat: Publish idempotence

### DIFF
--- a/google/cloud/pubsublite/cloudpubsub/internal/make_publisher.py
+++ b/google/cloud/pubsublite/cloudpubsub/internal/make_publisher.py
@@ -28,6 +28,7 @@ from google.cloud.pubsublite.cloudpubsub.internal.single_publisher import (
     AsyncSinglePublisher,
     SinglePublisher,
 )
+from google.cloud.pubsublite.internal.publisher_client_id import PublisherClientId
 from google.cloud.pubsublite.internal.wire.make_publisher import (
     make_publisher as make_wire_publisher,
     DEFAULT_BATCHING_SETTINGS as WIRE_DEFAULT_BATCHING,
@@ -47,6 +48,7 @@ def make_async_publisher(
     credentials: Optional[Credentials] = None,
     client_options: Optional[ClientOptions] = None,
     metadata: Optional[Mapping[str, str]] = None,
+    client_id: Optional[PublisherClientId] = None,
 ) -> AsyncSinglePublisher:
     """
     Make a new publisher for the given topic.
@@ -58,6 +60,7 @@ def make_async_publisher(
       credentials: The credentials to use to connect. GOOGLE_DEFAULT_CREDENTIALS is used if None.
       client_options: Other options to pass to the client. Note that if you pass any you must set api_endpoint.
       metadata: Additional metadata to send with the RPC.
+      client_id: 128-bit unique client id. If set, enables publish idempotency for the session.
 
     Returns:
       A new AsyncPublisher.
@@ -75,6 +78,7 @@ def make_async_publisher(
             credentials=credentials,
             client_options=client_options,
             metadata=metadata,
+            client_id=client_id,
         )
 
     return AsyncSinglePublisherImpl(underlying_factory)
@@ -87,6 +91,7 @@ def make_publisher(
     credentials: Optional[Credentials] = None,
     client_options: Optional[ClientOptions] = None,
     metadata: Optional[Mapping[str, str]] = None,
+    client_id: Optional[PublisherClientId] = None,
 ) -> SinglePublisher:
     """
     Make a new publisher for the given topic.
@@ -98,6 +103,7 @@ def make_publisher(
       credentials: The credentials to use to connect. GOOGLE_DEFAULT_CREDENTIALS is used if None.
       client_options: Other options to pass to the client. Note that if you pass any you must set api_endpoint.
       metadata: Additional metadata to send with the RPC.
+      client_id: 128-bit unique client id. If set, enables publish idempotency for the session.
 
     Returns:
       A new Publisher.
@@ -113,5 +119,6 @@ def make_publisher(
             credentials=credentials,
             client_options=client_options,
             metadata=metadata,
+            client_id=client_id,
         )
     )

--- a/google/cloud/pubsublite/cloudpubsub/publisher_client.py
+++ b/google/cloud/pubsublite/cloudpubsub/publisher_client.py
@@ -83,7 +83,7 @@ class PublisherClient(PublisherClientInterface, ConstructableFromServiceAccount)
             credentials: If provided, the credentials to use when connecting.
             transport: The transport to use. Must correspond to an asyncio transport.
             client_options: The client options to use when connecting. If used, must explicitly set `api_endpoint`.
-            enable_idempotence: Whether to enable publish idempotence, where the server will ensure that unique messages within a single publisher session are stored only once.
+            enable_idempotence: Whether idempotence is enabled, where the server will ensure that unique messages within a single publisher session are stored only once.
         """
         client_id = _get_client_id(enable_idempotence)
         self._impl = MultiplexedPublisherClient(
@@ -158,7 +158,7 @@ class AsyncPublisherClient(
             credentials: If provided, the credentials to use when connecting.
             transport: The transport to use. Must correspond to an asyncio transport.
             client_options: The client options to use when connecting. If used, must explicitly set `api_endpoint`.
-            enable_idempotence: Whether to enable publish idempotence, where the server will ensure that unique messages within a single publisher session are stored only once.
+            enable_idempotence: Whether idempotence is enabled, where the server will ensure that unique messages within a single publisher session are stored only once.
         """
         client_id = _get_client_id(enable_idempotence)
         self._impl = MultiplexedAsyncPublisherClient(

--- a/google/cloud/pubsublite/cloudpubsub/publisher_client.py
+++ b/google/cloud/pubsublite/cloudpubsub/publisher_client.py
@@ -14,6 +14,7 @@
 
 from concurrent.futures import Future
 from typing import Optional, Mapping, Union
+from uuid import uuid4
 
 from google.api_core.client_options import ClientOptions
 from google.auth.credentials import Credentials
@@ -36,12 +37,17 @@ from google.cloud.pubsublite.cloudpubsub.publisher_client_interface import (
 from google.cloud.pubsublite.internal.constructable_from_service_account import (
     ConstructableFromServiceAccount,
 )
+from google.cloud.pubsublite.internal.publisher_client_id import PublisherClientId
 from google.cloud.pubsublite.internal.require_started import RequireStarted
 from google.cloud.pubsublite.internal.wire.make_publisher import (
     DEFAULT_BATCHING_SETTINGS as WIRE_DEFAULT_BATCHING,
 )
 from google.cloud.pubsublite.types import TopicPath
 from overrides import overrides
+
+
+def _get_client_id(enable_idempotence: bool):
+    return PublisherClientId(uuid4().bytes) if enable_idempotence else None
 
 
 class PublisherClient(PublisherClientInterface, ConstructableFromServiceAccount):
@@ -53,7 +59,7 @@ class PublisherClient(PublisherClientInterface, ConstructableFromServiceAccount)
     """
 
     _impl: PublisherClientInterface
-    _require_stared: RequireStarted
+    _require_started: RequireStarted
 
     DEFAULT_BATCHING_SETTINGS = WIRE_DEFAULT_BATCHING
     """
@@ -67,6 +73,7 @@ class PublisherClient(PublisherClientInterface, ConstructableFromServiceAccount)
         credentials: Optional[Credentials] = None,
         transport: str = "grpc_asyncio",
         client_options: Optional[ClientOptions] = None,
+        enable_idempotence: bool = True,
     ):
         """
         Create a new PublisherClient.
@@ -76,7 +83,9 @@ class PublisherClient(PublisherClientInterface, ConstructableFromServiceAccount)
             credentials: If provided, the credentials to use when connecting.
             transport: The transport to use. Must correspond to an asyncio transport.
             client_options: The client options to use when connecting. If used, must explicitly set `api_endpoint`.
+            enable_idempotence: Whether to enable publish idempotence, where the server will ensure that unique messages within a single publisher session are stored only once.
         """
+        client_id = _get_client_id(enable_idempotence)
         self._impl = MultiplexedPublisherClient(
             lambda topic: make_publisher(
                 topic=topic,
@@ -84,9 +93,10 @@ class PublisherClient(PublisherClientInterface, ConstructableFromServiceAccount)
                 credentials=credentials,
                 client_options=client_options,
                 transport=transport,
+                client_id=client_id,
             )
         )
-        self._require_stared = RequireStarted()
+        self._require_started = RequireStarted()
 
     @overrides
     def publish(
@@ -96,21 +106,21 @@ class PublisherClient(PublisherClientInterface, ConstructableFromServiceAccount)
         ordering_key: str = "",
         **attrs: Mapping[str, str],
     ) -> "Future[str]":
-        self._require_stared.require_started()
+        self._require_started.require_started()
         return self._impl.publish(
             topic=topic, data=data, ordering_key=ordering_key, **attrs
         )
 
     @overrides
     def __enter__(self):
-        self._require_stared.__enter__()
+        self._require_started.__enter__()
         self._impl.__enter__()
         return self
 
     @overrides
     def __exit__(self, exc_type, exc_value, traceback):
         self._impl.__exit__(exc_type, exc_value, traceback)
-        self._require_stared.__exit__(exc_type, exc_value, traceback)
+        self._require_started.__exit__(exc_type, exc_value, traceback)
 
 
 class AsyncPublisherClient(
@@ -124,7 +134,7 @@ class AsyncPublisherClient(
     """
 
     _impl: AsyncPublisherClientInterface
-    _require_stared: RequireStarted
+    _require_started: RequireStarted
 
     DEFAULT_BATCHING_SETTINGS = WIRE_DEFAULT_BATCHING
     """
@@ -138,6 +148,7 @@ class AsyncPublisherClient(
         credentials: Optional[Credentials] = None,
         transport: str = "grpc_asyncio",
         client_options: Optional[ClientOptions] = None,
+        enable_idempotence: bool = True,
     ):
         """
         Create a new AsyncPublisherClient.
@@ -147,7 +158,9 @@ class AsyncPublisherClient(
             credentials: If provided, the credentials to use when connecting.
             transport: The transport to use. Must correspond to an asyncio transport.
             client_options: The client options to use when connecting. If used, must explicitly set `api_endpoint`.
+            enable_idempotence: Whether to enable publish idempotence, where the server will ensure that unique messages within a single publisher session are stored only once.
         """
+        client_id = _get_client_id(enable_idempotence)
         self._impl = MultiplexedAsyncPublisherClient(
             lambda topic: make_async_publisher(
                 topic=topic,
@@ -155,9 +168,10 @@ class AsyncPublisherClient(
                 credentials=credentials,
                 client_options=client_options,
                 transport=transport,
+                client_id=client_id,
             )
         )
-        self._require_stared = RequireStarted()
+        self._require_started = RequireStarted()
 
     @overrides
     async def publish(
@@ -167,18 +181,18 @@ class AsyncPublisherClient(
         ordering_key: str = "",
         **attrs: Mapping[str, str],
     ) -> str:
-        self._require_stared.require_started()
+        self._require_started.require_started()
         return await self._impl.publish(
             topic=topic, data=data, ordering_key=ordering_key, **attrs
         )
 
     @overrides
     async def __aenter__(self):
-        self._require_stared.__enter__()
+        self._require_started.__enter__()
         await self._impl.__aenter__()
         return self
 
     @overrides
     async def __aexit__(self, exc_type, exc_value, traceback):
         await self._impl.__aexit__(exc_type, exc_value, traceback)
-        self._require_stared.__exit__(exc_type, exc_value, traceback)
+        self._require_started.__exit__(exc_type, exc_value, traceback)

--- a/google/cloud/pubsublite/internal/publish_sequence_number.py
+++ b/google/cloud/pubsublite/internal/publish_sequence_number.py
@@ -1,0 +1,22 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import NamedTuple
+
+
+class PublishSequenceNumber(NamedTuple):
+    value: int
+
+    def next(self) -> "PublishSequenceNumber":
+        return PublishSequenceNumber(self.value + 1)

--- a/google/cloud/pubsublite/internal/publisher_client_id.py
+++ b/google/cloud/pubsublite/internal/publisher_client_id.py
@@ -1,0 +1,19 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import NamedTuple
+
+
+class PublisherClientId(NamedTuple):
+    value: bytes

--- a/google/cloud/pubsublite/internal/wire/make_publisher.py
+++ b/google/cloud/pubsublite/internal/wire/make_publisher.py
@@ -19,6 +19,9 @@ from google.cloud.pubsub_v1.types import BatchSettings
 from google.cloud.pubsublite.admin_client import AdminClient
 from google.cloud.pubsublite.internal.endpoints import regional_endpoint
 from google.cloud.pubsublite.internal.publisher_client_id import PublisherClientId
+from google.cloud.pubsublite.internal.publish_sequence_number import (
+    PublishSequenceNumber,
+)
 from google.cloud.pubsublite.internal.wire.client_cache import ClientCache
 from google.cloud.pubsublite.internal.wire.default_routing_policy import (
     DefaultRoutingPolicy,
@@ -116,6 +119,7 @@ def make_publisher(
             initial_request,
             per_partition_batching_settings,
             GapicConnectionFactory(connection_factory),
+            PublishSequenceNumber(0),
         )
 
     def policy_factory(partition_count: int):

--- a/google/cloud/pubsublite/internal/wire/make_publisher.py
+++ b/google/cloud/pubsublite/internal/wire/make_publisher.py
@@ -18,6 +18,7 @@ from google.cloud.pubsub_v1.types import BatchSettings
 
 from google.cloud.pubsublite.admin_client import AdminClient
 from google.cloud.pubsublite.internal.endpoints import regional_endpoint
+from google.cloud.pubsublite.internal.publisher_client_id import PublisherClientId
 from google.cloud.pubsublite.internal.wire.client_cache import ClientCache
 from google.cloud.pubsublite.internal.wire.default_routing_policy import (
     DefaultRoutingPolicy,
@@ -60,6 +61,7 @@ def make_publisher(
     credentials: Optional[Credentials] = None,
     client_options: Optional[ClientOptions] = None,
     metadata: Optional[Mapping[str, str]] = None,
+    client_id: Optional[PublisherClientId] = None,
 ) -> Publisher:
     """
     Make a new publisher for the given topic.
@@ -71,6 +73,7 @@ def make_publisher(
       credentials: The credentials to use to connect. GOOGLE_DEFAULT_CREDENTIALS is used if None.
       client_options: Other options to pass to the client. Note that if you pass any you must set api_endpoint.
       metadata: Additional metadata to send with the RPC.
+      client_id: 128-bit unique client id. If set, enables publish idempotency for the session.
 
     Returns:
       A new Publisher.
@@ -104,8 +107,13 @@ def make_publisher(
                 requests, metadata=list(final_metadata.items())
             )
 
+        initial_request = InitialPublishRequest(
+            topic=str(topic), partition=partition.value
+        )
+        if client_id:
+            initial_request.client_id = client_id.value
         return SinglePartitionPublisher(
-            InitialPublishRequest(topic=str(topic), partition=partition.value),
+            initial_request,
             per_partition_batching_settings,
             GapicConnectionFactory(connection_factory),
         )

--- a/google/cloud/pubsublite/internal/wire/single_partition_publisher.py
+++ b/google/cloud/pubsublite/internal/wire/single_partition_publisher.py
@@ -188,7 +188,7 @@ class SinglePartitionPublisher(
         aggregate.message_publish_request.messages = [
             item.request.message for item in batch
         ]
-        if len(self._initial.client_id) > 0:
+        if self._initial.client_id:
             aggregate.message_publish_request.first_sequence_number = batch[
                 0
             ].request.sequence_number.value

--- a/google/cloud/pubsublite/internal/wire/single_partition_publisher.py
+++ b/google/cloud/pubsublite/internal/wire/single_partition_publisher.py
@@ -83,7 +83,7 @@ class SinglePartitionPublisher(
         initial: InitialPublishRequest,
         batching_settings: BatchSettings,
         factory: ConnectionFactory[PublishRequest, PublishResponse],
-        initial_sequence: PublishSequenceNumber = PublishSequenceNumber(0),
+        initial_sequence: PublishSequenceNumber,
     ):
         self._initial = initial
         self._batching_settings = batching_settings

--- a/google/cloud/pubsublite/types/message_metadata.py
+++ b/google/cloud/pubsublite/types/message_metadata.py
@@ -20,6 +20,21 @@ from google.cloud.pubsublite.types.partition import Partition
 
 
 class MessageMetadata(NamedTuple):
+    """Information about a message in Pub/Sub Lite.
+
+    Attributes:
+        partition (Partition):
+            The partition of the topic that the message was published to.
+        cursor (Cursor):
+            A cursor containing the offset that the message was assigned.
+            If this MessageMetadata was returned for a publish result and
+            publish idempotence was enabled, the offset may be -1 when the
+            message was identified as a duplicate of an already successfully
+            published message, but the server did not have sufficient
+            information to return the message's offset at publish time. Messages
+            received by subscribers will always have the correct offset.
+    """
+
     partition: Partition
     cursor: Cursor
 

--- a/tests/unit/pubsublite/internal/wire/single_partition_publisher_test.py
+++ b/tests/unit/pubsublite/internal/wire/single_partition_publisher_test.py
@@ -15,7 +15,7 @@
 import asyncio
 from unittest.mock import AsyncMock, call, MagicMock
 from collections import defaultdict
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import pytest
 from google.cloud.pubsub_v1.types import BatchSettings
@@ -32,6 +32,9 @@ from google.cloud.pubsublite_v1.types.publisher import (
     MessagePublishResponse,
 )
 from google.cloud.pubsublite_v1.types.common import PubSubMessage, Cursor
+from google.cloud.pubsublite.internal.publish_sequence_number import (
+    PublishSequenceNumber,
+)
 from google.cloud.pubsublite.internal.wire.single_partition_publisher import (
     SinglePartitionPublisher,
 )
@@ -46,6 +49,8 @@ BATCHING_SETTINGS = BatchSettings(
 
 # All test coroutines will be treated as marked.
 pytestmark = pytest.mark.asyncio
+
+CursorRange = MessagePublishResponse.CursorRange
 
 
 @pytest.fixture()
@@ -65,6 +70,13 @@ def connection_factory(default_connection):
 @pytest.fixture()
 def initial_request():
     return PublishRequest(initial_request=InitialPublishRequest(topic="mytopic"))
+
+
+@pytest.fixture()
+def initial_request_with_client_id():
+    return PublishRequest(
+        initial_request=InitialPublishRequest(topic="mytopic", client_id=b"publisher")
+    )
 
 
 class QueuePair:
@@ -103,17 +115,45 @@ def publisher(connection_factory, initial_request):
     )
 
 
-def as_publish_request(messages: List[PubSubMessage]):
+@pytest.fixture
+def initial_sequence():
+    return PublishSequenceNumber(514)
+
+
+@pytest.fixture()
+def idempotent_publisher(
+    connection_factory, initial_request_with_client_id, initial_sequence
+):
+    return SinglePartitionPublisher(
+        initial_request_with_client_id.initial_request,
+        BATCHING_SETTINGS,
+        connection_factory,
+        initial_sequence,
+    )
+
+
+def as_publish_request(
+    messages: List[PubSubMessage],
+    first_sequence: Optional[PublishSequenceNumber] = None,
+):
     req = PublishRequest()
     req.message_publish_request.messages = messages
+    if first_sequence:
+        req.message_publish_request.first_sequence_number = first_sequence.value
     return req
 
 
-def as_publish_response(start_cursor: int):
+def cursor_range(start_offset, start_index, end_index: int):
+    return CursorRange(
+        start_cursor=Cursor(offset=start_offset),
+        start_index=start_index,
+        end_index=end_index,
+    )
+
+
+def as_publish_response(cursor_ranges: List[CursorRange]):
     return PublishResponse(
-        message_response=MessagePublishResponse(
-            start_cursor=Cursor(offset=start_cursor)
-        )
+        message_response=MessagePublishResponse(cursor_ranges=cursor_ranges)
     )
 
 
@@ -165,7 +205,7 @@ async def test_basic_publish_after_timeout(
         assert not publish_fut2.done()
 
         # Send the connection response
-        await read_result_queue.put(as_publish_response(100))
+        await read_result_queue.put(as_publish_response([cursor_range(100, 0, 2)]))
         cursor1 = (await publish_fut1).cursor
         cursor2 = (await publish_fut2).cursor
         assert cursor1.offset == 100
@@ -173,9 +213,10 @@ async def test_basic_publish_after_timeout(
 
 
 async def test_publishes_multi_cycle(
-    publisher: Publisher,
+    idempotent_publisher: Publisher,
     default_connection,
-    initial_request,
+    initial_request_with_client_id,
+    initial_sequence,
     asyncio_sleep,
     sleep_queues,
 ):
@@ -195,14 +236,16 @@ async def test_publishes_multi_cycle(
     )
     write_result_queue.put_nowait(None)
     read_result_queue.put_nowait(PublishResponse(initial_response={}))
-    async with publisher:
+    async with idempotent_publisher:
         # Set up connection
         await write_called_queue.get()
         await read_called_queue.get()
-        default_connection.write.assert_has_calls([call(initial_request)])
+        default_connection.write.assert_has_calls(
+            [call(initial_request_with_client_id)]
+        )
 
         # Write message 1
-        publish_fut1 = asyncio.ensure_future(publisher.publish(message1))
+        publish_fut1 = asyncio.ensure_future(idempotent_publisher.publish(message1))
         assert not publish_fut1.done()
 
         # Wait for writes to be waiting
@@ -214,7 +257,10 @@ async def test_publishes_multi_cycle(
         await write_called_queue.get()
         await write_result_queue.put(None)
         default_connection.write.assert_has_calls(
-            [call(initial_request), call(as_publish_request([message1]))]
+            [
+                call(initial_request_with_client_id),
+                call(as_publish_request([message1], initial_sequence)),
+            ]
         )
         assert not publish_fut1.done()
 
@@ -223,7 +269,7 @@ async def test_publishes_multi_cycle(
         asyncio_sleep.assert_has_calls([call(FLUSH_SECONDS), call(FLUSH_SECONDS)])
 
         # Write message 2
-        publish_fut2 = asyncio.ensure_future(publisher.publish(message2))
+        publish_fut2 = asyncio.ensure_future(idempotent_publisher.publish(message2))
         assert not publish_fut2.done()
 
         # Handle the connection write
@@ -232,20 +278,24 @@ async def test_publishes_multi_cycle(
         await write_result_queue.put(None)
         default_connection.write.assert_has_calls(
             [
-                call(initial_request),
-                call(as_publish_request([message1])),
-                call(as_publish_request([message2])),
+                call(initial_request_with_client_id),
+                call(as_publish_request([message1], initial_sequence)),
+                call(
+                    as_publish_request(
+                        [message2], PublishSequenceNumber(initial_sequence.value + 1)
+                    )
+                ),
             ]
         )
         assert not publish_fut1.done()
         assert not publish_fut2.done()
 
         # Send the connection responses
-        await read_result_queue.put(as_publish_response(100))
+        await read_result_queue.put(as_publish_response([cursor_range(100, 0, 1)]))
         cursor1 = (await publish_fut1).cursor
         assert cursor1.offset == 100
         assert not publish_fut2.done()
-        await read_result_queue.put(as_publish_response(105))
+        await read_result_queue.put(as_publish_response([cursor_range(105, 0, 1)]))
         cursor2 = (await publish_fut2).cursor
         assert cursor2.offset == 105
 
@@ -351,3 +401,110 @@ async def test_publishes_retried_on_restart(
                 call(as_publish_request([message2])),
             ]
         )
+
+
+async def test_missing_cursor_ranges(
+    idempotent_publisher: Publisher,
+    default_connection,
+    initial_request_with_client_id,
+    initial_sequence,
+    asyncio_sleep,
+    sleep_queues,
+):
+    sleep_called = sleep_queues[FLUSH_SECONDS].called
+    sleep_results = sleep_queues[FLUSH_SECONDS].results
+    message1 = PubSubMessage(data=b"msg1")
+    message2 = PubSubMessage(data=b"msg2")
+    message3 = PubSubMessage(data=b"msg3")
+    message4 = PubSubMessage(data=b"msg4")
+    message5 = PubSubMessage(data=b"msg5")
+    message6 = PubSubMessage(data=b"msg6")
+    message7 = PubSubMessage(data=b"msg7")
+    read_called_queue = asyncio.Queue()
+    read_result_queue = asyncio.Queue()
+    default_connection.read.side_effect = make_queue_waiter(
+        read_called_queue, read_result_queue
+    )
+    read_result_queue.put_nowait(PublishResponse(initial_response={}))
+    async with idempotent_publisher:
+        # Set up connection
+        await read_called_queue.get()
+        default_connection.write.assert_has_calls(
+            [call(initial_request_with_client_id)]
+        )
+
+        # Write messages
+        publish_fut1 = asyncio.ensure_future(idempotent_publisher.publish(message1))
+        publish_fut2 = asyncio.ensure_future(idempotent_publisher.publish(message2))
+        publish_fut3 = asyncio.ensure_future(idempotent_publisher.publish(message3))
+        publish_fut4 = asyncio.ensure_future(idempotent_publisher.publish(message4))
+        publish_fut5 = asyncio.ensure_future(idempotent_publisher.publish(message5))
+        publish_fut6 = asyncio.ensure_future(idempotent_publisher.publish(message6))
+        publish_fut7 = asyncio.ensure_future(idempotent_publisher.publish(message7))
+
+        # Wait for writes to be waiting
+        await sleep_called.get()
+        asyncio_sleep.assert_called_with(FLUSH_SECONDS)
+
+        # Handle the connection write
+        write_future = asyncio.Future()
+
+        async def write(val: PublishRequest):
+            write_future.set_result(None)
+
+        default_connection.write.side_effect = write
+        await sleep_results.put(None)
+        await write_future
+        default_connection.write.assert_has_calls(
+            [
+                call(initial_request_with_client_id),
+                call(
+                    as_publish_request(
+                        [
+                            message1,
+                            message2,
+                            message3,
+                            message4,
+                            message5,
+                            message6,
+                            message7,
+                        ],
+                        initial_sequence,
+                    )
+                ),
+            ]
+        )
+        assert not publish_fut1.done()
+        assert not publish_fut2.done()
+        assert not publish_fut3.done()
+        assert not publish_fut4.done()
+        assert not publish_fut5.done()
+        assert not publish_fut6.done()
+        assert not publish_fut7.done()
+
+        # Send the connection response
+        # The server should not respond with unsorted cursor ranges, but check
+        # that it is handled.
+        await read_result_queue.put(
+            as_publish_response(
+                [
+                    cursor_range(50, 4, 5),
+                    cursor_range(80, 5, 6),
+                    cursor_range(10, 1, 3),
+                ]
+            )
+        )
+        cursor1 = (await publish_fut1).cursor
+        cursor2 = (await publish_fut2).cursor
+        cursor3 = (await publish_fut3).cursor
+        cursor4 = (await publish_fut4).cursor
+        cursor5 = (await publish_fut5).cursor
+        cursor6 = (await publish_fut6).cursor
+        cursor7 = (await publish_fut7).cursor
+        assert cursor1.offset == -1
+        assert cursor2.offset == 10
+        assert cursor3.offset == 11
+        assert cursor4.offset == -1
+        assert cursor5.offset == 50
+        assert cursor6.offset == 80
+        assert cursor7.offset == -1

--- a/tests/unit/pubsublite/internal/wire/single_partition_publisher_test.py
+++ b/tests/unit/pubsublite/internal/wire/single_partition_publisher_test.py
@@ -111,7 +111,10 @@ def asyncio_sleep(monkeypatch, sleep_queues):
 @pytest.fixture()
 def publisher(connection_factory, initial_request):
     return SinglePartitionPublisher(
-        initial_request.initial_request, BATCHING_SETTINGS, connection_factory
+        initial_request.initial_request,
+        BATCHING_SETTINGS,
+        connection_factory,
+        PublishSequenceNumber(0),
     )
 
 


### PR DESCRIPTION
Implements publish idempotence (default enabled), where the server will ensure that unique messages within a single publisher session are only stored once.