### PR TITLE
chore: librarian release pull request: 20251215T134436Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:8e2c32496077054105bd06c54a59d6a6694287bc053588e24debe6da6920ad91
 libraries:
   - id: google-cloud-pubsublite
-    version: 1.12.0
+    version: 1.13.0
     last_generated_commit: 5400ccce473c439885bd6bf2924fd242271bfcab
     apis:
       - path: google/cloud/pubsublite/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 [1]: https://pypi.org/project/google-cloud-pubsublite/#history
 
+## [1.13.0](https://github.com/googleapis/python-pubsublite/compare/v1.12.0...v1.13.0) (2025-12-15)
+
+
+### Features
+
+* Add support for Python 3.14 (#563) ([747fd6a380a77619f4b3c1e391bae3645d48d4aa](https://github.com/googleapis/python-pubsublite/commit/747fd6a380a77619f4b3c1e391bae3645d48d4aa))
+
+
+### Bug Fixes
+
+* Deprecate credentials_file argument (#559) ([c4f2cafc3c6309b523629879bdd09d9ac27d9184](https://github.com/googleapis/python-pubsublite/commit/c4f2cafc3c6309b523629879bdd09d9ac27d9184))
+* resolve issues where pre-release versions of dependencies are installed (#548) ([218278fc2524fe1cd9a9e0b317ca950ad4f150cc](https://github.com/googleapis/python-pubsublite/commit/218278fc2524fe1cd9a9e0b317ca950ad4f150cc))
+* remove setup.cfg configuration for creating universal wheels (#551) ([a45e534ac0fac29f72adb2006ba640faa6a232f6](https://github.com/googleapis/python-pubsublite/commit/a45e534ac0fac29f72adb2006ba640faa6a232f6))
+
 ## [1.12.0](https://github.com/googleapis/python-pubsublite/compare/v1.11.1...v1.12.0) (2025-02-24)
 
 

--- a/google/cloud/pubsublite/gapic_version.py
+++ b/google/cloud/pubsublite/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "1.12.0"  # {x-release-please-version}
+__version__ = "1.13.0"  # {x-release-please-version}

--- a/google/cloud/pubsublite_v1/gapic_version.py
+++ b/google/cloud/pubsublite_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "1.12.0"  # {x-release-please-version}
+__version__ = "1.13.0"  # {x-release-please-version}

--- a/samples/generated_samples/snippet_metadata_google.cloud.pubsublite.v1.json
+++ b/samples/generated_samples/snippet_metadata_google.cloud.pubsublite.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-pubsublite",
-    "version": "1.12.0"
+    "version": "1.13.0"
   },
   "snippets": [
     {


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:8e2c32496077054105bd06c54a59d6a6694287bc053588e24debe6da6920ad91
<details><summary>google-cloud-pubsublite: 1.13.0</summary>

## [1.13.0](https://github.com/googleapis/python-pubsublite/compare/v1.12.0...v1.13.0) (2025-12-15)

### Features

* Add support for Python 3.14 (#563) ([747fd6a3](https://github.com/googleapis/python-pubsublite/commit/747fd6a3))

### Bug Fixes

* resolve issues where pre-release versions of dependencies are installed (#548) ([218278fc](https://github.com/googleapis/python-pubsublite/commit/218278fc))

* remove setup.cfg configuration for creating universal wheels (#551) ([a45e534a](https://github.com/googleapis/python-pubsublite/commit/a45e534a))

* Deprecate credentials_file argument (#559) (PiperOrigin-RevId: 816753840) ([c4f2cafc](https://github.com/googleapis/python-pubsublite/commit/c4f2cafc))

</details>