### PR TITLE
feat(pubsublite): Support Google Managed Kafka backend

### DIFF
--- a/google/cloud/pubsublite/cloudpubsub/__init__.py
+++ b/google/cloud/pubsublite/cloudpubsub/__init__.py
@@ -15,6 +15,7 @@
 # flake8: noqa
 from .message_transformer import MessageTransformer
 from .nack_handler import NackHandler
+from .messaging_backend import MessagingBackend
 from .publisher_client import AsyncPublisherClient, PublisherClient
 from .publisher_client_interface import (
     AsyncPublisherClientInterface,
@@ -32,6 +33,7 @@ __all__ = (
     "AsyncSubscriberClient",
     "AsyncSubscriberClientInterface",
     "MessageTransformer",
+    "MessagingBackend",
     "NackHandler",
     "PublisherClient",
     "PublisherClientInterface",

--- a/google/cloud/pubsublite/cloudpubsub/internal/kafka_publisher.py
+++ b/google/cloud/pubsublite/cloudpubsub/internal/kafka_publisher.py
@@ -34,6 +34,7 @@ def _import_confluent_kafka():
     if confluent_kafka is None:
         try:
             import confluent_kafka as ck
+
             confluent_kafka = ck
         except ImportError:
             raise ImportError(
@@ -47,7 +48,9 @@ class KafkaPublisherClient(PublisherClientInterface):
     """A Kafka-based PublisherClient that publishes to Google Managed Kafka."""
 
     def __init__(
-        self, bootstrap_servers: str, kafka_properties: Optional[Mapping[str, Any]] = None
+        self,
+        bootstrap_servers: str,
+        kafka_properties: Optional[Mapping[str, Any]] = None,
     ):
         _import_confluent_kafka()
         config = {
@@ -87,6 +90,7 @@ class KafkaPublisherClient(PublisherClientInterface):
                     from google.cloud.pubsublite.cloudpubsub.message_transforms import (
                         _decode_attribute_event_time_proto,
                     )
+
                     ts = _decode_attribute_event_time_proto(v)
                     event_time_val = f"{ts.seconds}.{ts.nanos:09d}".encode("utf-8")
                     headers.append(("pubsublite.event_time", event_time_val))
@@ -138,7 +142,9 @@ class AsyncKafkaPublisherClient(AsyncPublisherClientInterface):
     """An asynchronous Kafka-based PublisherClient that publishes to Google Managed Kafka."""
 
     def __init__(
-        self, bootstrap_servers: str, kafka_properties: Optional[Mapping[str, Any]] = None
+        self,
+        bootstrap_servers: str,
+        kafka_properties: Optional[Mapping[str, Any]] = None,
     ):
         _import_confluent_kafka()
         config = {
@@ -154,7 +160,9 @@ class AsyncKafkaPublisherClient(AsyncPublisherClientInterface):
         self._producer = confluent_kafka.Producer(config)
         self._running = True
         self._poll_thread = threading.Thread(
-            target=self._poll_loop, name=f"async-kafka-publisher-poll-{id(self)}", daemon=True
+            target=self._poll_loop,
+            name=f"async-kafka-publisher-poll-{id(self)}",
+            daemon=True,
         )
         self._poll_thread.start()
 
@@ -179,6 +187,7 @@ class AsyncKafkaPublisherClient(AsyncPublisherClientInterface):
                     from google.cloud.pubsublite.cloudpubsub.message_transforms import (
                         _decode_attribute_event_time_proto,
                     )
+
                     ts = _decode_attribute_event_time_proto(v)
                     event_time_val = f"{ts.seconds}.{ts.nanos:09d}".encode("utf-8")
                     headers.append(("pubsublite.event_time", event_time_val))

--- a/google/cloud/pubsublite/cloudpubsub/internal/kafka_publisher.py
+++ b/google/cloud/pubsublite/cloudpubsub/internal/kafka_publisher.py
@@ -1,0 +1,227 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from concurrent.futures import Future
+import threading
+from typing import Mapping, Union, Optional, Any
+
+from google.api_core.exceptions import InternalServerError
+from google.cloud.pubsublite.cloudpubsub.publisher_client_interface import (
+    PublisherClientInterface,
+    AsyncPublisherClientInterface,
+)
+from google.cloud.pubsublite.types import TopicPath
+from google.cloud.pubsublite.internal.gmk_auth import gcp_oauth_callback
+
+# Lazy import confluent-kafka to avoid hard dependency
+confluent_kafka = None
+
+
+def _import_confluent_kafka():
+    global confluent_kafka
+    if confluent_kafka is None:
+        try:
+            import confluent_kafka as ck
+            confluent_kafka = ck
+        except ImportError:
+            raise ImportError(
+                "confluent-kafka is required for MANAGED_KAFKA backend. "
+                "Install it using `pip install google-cloud-pubsublite[kafka]` "
+                "or `pip install confluent-kafka`."
+            )
+
+
+class KafkaPublisherClient(PublisherClientInterface):
+    """A Kafka-based PublisherClient that publishes to Google Managed Kafka."""
+
+    def __init__(
+        self, bootstrap_servers: str, kafka_properties: Optional[Mapping[str, Any]] = None
+    ):
+        _import_confluent_kafka()
+        config = {
+            "bootstrap.servers": bootstrap_servers,
+            "security.protocol": "SASL_SSL",
+            "sasl.mechanisms": "OAUTHBEARER",
+            "oauth_cb": gcp_oauth_callback,
+            "enable.idempotence": True,
+        }
+        if kafka_properties:
+            # Filter out keys we manage, but allow overriding if user insists
+            config.update(kafka_properties)
+
+        self._producer = confluent_kafka.Producer(config)
+        self._running = True
+        self._poll_thread = threading.Thread(
+            target=self._poll_loop, name=f"kafka-publisher-poll-{id(self)}", daemon=True
+        )
+        self._poll_thread.start()
+
+    def _poll_loop(self):
+        while self._running:
+            self._producer.poll(0.1)
+
+    def publish(
+        self,
+        topic: Union[TopicPath, str],
+        data: bytes,
+        ordering_key: str = "",
+        **attrs: Mapping[str, str],
+    ) -> "Future[str]":
+        future = Future()
+        headers = []
+        for k, v in attrs.items():
+            if k == "x-goog-pubsublite-event-time":
+                try:
+                    from google.cloud.pubsublite.cloudpubsub.message_transforms import (
+                        _decode_attribute_event_time_proto,
+                    )
+                    ts = _decode_attribute_event_time_proto(v)
+                    event_time_val = f"{ts.seconds}.{ts.nanos:09d}".encode("utf-8")
+                    headers.append(("pubsublite.event_time", event_time_val))
+                except Exception:
+                    headers.append((k, v.encode("utf-8")))
+            else:
+                headers.append((k, v.encode("utf-8")))
+
+        key = ordering_key.encode("utf-8") if ordering_key else None
+        topic_str = str(topic) if isinstance(topic, TopicPath) else topic
+
+        def delivery_callback(err, msg):
+            if err is not None:
+                future.set_exception(
+                    InternalServerError(f"Kafka publish failed: {err}")
+                )
+            else:
+                # Format message ID as partition:offset to match PSL-like ID
+                msg_id = f"{msg.partition()}:{msg.offset()}"
+                future.set_result(msg_id)
+
+        try:
+            self._producer.produce(
+                topic=topic_str,
+                value=data,
+                key=key,
+                headers=headers,
+                callback=delivery_callback,
+            )
+        except Exception as e:
+            future.set_exception(e)
+
+        return future
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self._shutdown()
+
+    def _shutdown(self):
+        self._running = False
+        if self._poll_thread.is_alive():
+            self._poll_thread.join()
+        self._producer.flush()
+
+
+class AsyncKafkaPublisherClient(AsyncPublisherClientInterface):
+    """An asynchronous Kafka-based PublisherClient that publishes to Google Managed Kafka."""
+
+    def __init__(
+        self, bootstrap_servers: str, kafka_properties: Optional[Mapping[str, Any]] = None
+    ):
+        _import_confluent_kafka()
+        config = {
+            "bootstrap.servers": bootstrap_servers,
+            "security.protocol": "SASL_SSL",
+            "sasl.mechanisms": "OAUTHBEARER",
+            "oauth_cb": gcp_oauth_callback,
+            "enable.idempotence": True,
+        }
+        if kafka_properties:
+            config.update(kafka_properties)
+
+        self._producer = confluent_kafka.Producer(config)
+        self._running = True
+        self._poll_thread = threading.Thread(
+            target=self._poll_loop, name=f"async-kafka-publisher-poll-{id(self)}", daemon=True
+        )
+        self._poll_thread.start()
+
+    def _poll_loop(self):
+        while self._running:
+            self._producer.poll(0.1)
+
+    async def publish(
+        self,
+        topic: Union[TopicPath, str],
+        data: bytes,
+        ordering_key: str = "",
+        **attrs: Mapping[str, str],
+    ) -> str:
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
+
+        headers = []
+        for k, v in attrs.items():
+            if k == "x-goog-pubsublite-event-time":
+                try:
+                    from google.cloud.pubsublite.cloudpubsub.message_transforms import (
+                        _decode_attribute_event_time_proto,
+                    )
+                    ts = _decode_attribute_event_time_proto(v)
+                    event_time_val = f"{ts.seconds}.{ts.nanos:09d}".encode("utf-8")
+                    headers.append(("pubsublite.event_time", event_time_val))
+                except Exception:
+                    headers.append((k, v.encode("utf-8")))
+            else:
+                headers.append((k, v.encode("utf-8")))
+
+        key = ordering_key.encode("utf-8") if ordering_key else None
+        topic_str = str(topic) if isinstance(topic, TopicPath) else topic
+
+        def delivery_callback(err, msg):
+            if err is not None:
+                loop.call_soon_threadsafe(
+                    future.set_exception,
+                    InternalServerError(f"Kafka publish failed: {err}"),
+                )
+            else:
+                msg_id = f"{msg.partition()}:{msg.offset()}"
+                loop.call_soon_threadsafe(future.set_result, msg_id)
+
+        try:
+            self._producer.produce(
+                topic=topic_str,
+                value=data,
+                key=key,
+                headers=headers,
+                callback=delivery_callback,
+            )
+        except Exception as e:
+            future.set_exception(e)
+
+        return await future
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._shutdown)
+
+    def _shutdown(self):
+        self._running = False
+        if self._poll_thread.is_alive():
+            self._poll_thread.join()
+        self._producer.flush()

--- a/google/cloud/pubsublite/cloudpubsub/internal/kafka_subscriber.py
+++ b/google/cloud/pubsublite/cloudpubsub/internal/kafka_subscriber.py
@@ -16,7 +16,7 @@ import asyncio
 import logging
 import queue
 import threading
-from typing import Mapping, Union, Optional, Any, Set, List
+from typing import Mapping, Optional, Any, Set, List
 
 from google.pubsub_v1 import PubsubMessage
 from google.protobuf.timestamp_pb2 import Timestamp
@@ -42,6 +42,7 @@ def _import_confluent_kafka():
     if confluent_kafka is None:
         try:
             import confluent_kafka as ck
+
             confluent_kafka = ck
         except ImportError:
             raise ImportError(
@@ -160,16 +161,14 @@ class KafkaAsyncSingleSubscriber(AsyncSingleSubscriber):
                     logger.error(f"Kafka consumer error: {msg.error()}")
                     # We should probably fail the subscriber here.
                     # In asyncio, we can propagate exception to the queue.
-                    self._loop.call_soon_threadsafe(
-                        self._queue.put_nowait, msg.error()
-                    )
+                    self._loop.call_soon_threadsafe(self._queue.put_nowait, msg.error())
                     break
 
             # 3. Process message
             try:
                 wrapped_msg = self._convert_message(msg)
                 self._loop.call_soon_threadsafe(self._queue.put_nowait, wrapped_msg)
-            except Exception as e:
+            except Exception:
                 logger.exception("Failed to process consumer record")
 
     def _process_commits(self):
@@ -241,9 +240,7 @@ class KafkaAsyncSingleSubscriber(AsyncSingleSubscriber):
                 if count == 0:
                     pb.attributes[k] = v.decode("utf-8", errors="replace")
                 else:
-                    pb.attributes[f"{k}.{count}"] = v.decode(
-                        "utf-8", errors="replace"
-                    )
+                    pb.attributes[f"{k}.{count}"] = v.decode("utf-8", errors="replace")
                 header_counts[k] = count + 1
 
         # Add Kafka metadata

--- a/google/cloud/pubsublite/cloudpubsub/internal/kafka_subscriber.py
+++ b/google/cloud/pubsublite/cloudpubsub/internal/kafka_subscriber.py
@@ -1,0 +1,288 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import logging
+import queue
+import threading
+from typing import Mapping, Union, Optional, Any, Set, List
+
+from google.pubsub_v1 import PubsubMessage
+from google.protobuf.timestamp_pb2 import Timestamp
+from google.cloud.pubsub_v1.subscriber.message import Message
+
+from google.cloud.pubsublite.cloudpubsub.internal.single_subscriber import (
+    AsyncSingleSubscriber,
+)
+from google.cloud.pubsublite.cloudpubsub.internal.wrapped_message import (
+    WrappedMessage,
+    AckId,
+)
+from google.cloud.pubsublite.types import Partition, SubscriptionPath
+from google.cloud.pubsublite.internal.gmk_auth import gcp_oauth_callback
+
+# Lazy import confluent-kafka
+confluent_kafka = None
+logger = logging.getLogger(__name__)
+
+
+def _import_confluent_kafka():
+    global confluent_kafka
+    if confluent_kafka is None:
+        try:
+            import confluent_kafka as ck
+            confluent_kafka = ck
+        except ImportError:
+            raise ImportError(
+                "confluent-kafka is required for MANAGED_KAFKA backend. "
+                "Install it using `pip install google-cloud-pubsublite[kafka]` "
+                "or `pip install confluent-kafka`."
+            )
+
+
+def _parse_event_time_header(val: bytes) -> Optional[Timestamp]:
+    try:
+        s = val.decode("utf-8")
+        ts = Timestamp()
+        if "." in s:
+            parts = s.split(".")
+            ts.seconds = int(parts[0])
+            # Pad nanos if needed (Go writes %09d, so it should be 9 digits)
+            nanos_str = parts[1]
+            if len(nanos_str) < 9:
+                nanos_str = nanos_str.ljust(9, "0")
+            ts.nanos = int(nanos_str[:9])
+        else:
+            ts.seconds = int(s)
+            ts.nanos = 0
+        return ts
+    except Exception as e:
+        logger.warning(f"Failed to parse event time header {val}: {e}")
+        return None
+
+
+class KafkaAsyncSingleSubscriber(AsyncSingleSubscriber):
+    """A Kafka-based AsyncSingleSubscriber that consumes from Google Managed Kafka."""
+
+    def __init__(
+        self,
+        subscription: SubscriptionPath,
+        fixed_partitions: Optional[Set[Partition]],
+        bootstrap_servers: str,
+        kafka_topic: str,
+        kafka_properties: Optional[Mapping[str, Any]] = None,
+    ):
+        _import_confluent_kafka()
+        self._subscription = subscription
+        self._fixed_partitions = fixed_partitions
+        self._bootstrap_servers = bootstrap_servers
+        self._kafka_topic = kafka_topic
+        self._kafka_properties = kafka_properties
+
+        self._consumer = None
+        self._running = False
+        self._poll_thread = None
+        self._loop = None
+        self._queue = asyncio.Queue()
+        self._commit_queue = queue.Queue()
+
+    async def __aenter__(self):
+        self._loop = asyncio.get_running_loop()
+        group_id = str(self._subscription).replace("/", "-")
+
+        config = {
+            "bootstrap.servers": self._bootstrap_servers,
+            "group.id": group_id,
+            "security.protocol": "SASL_SSL",
+            "sasl.mechanisms": "OAUTHBEARER",
+            "oauth_cb": gcp_oauth_callback,
+            "enable.auto.commit": False,
+            "auto.offset.reset": "earliest",
+        }
+        if self._kafka_properties:
+            config.update(self._kafka_properties)
+
+        self._consumer = confluent_kafka.Consumer(config)
+
+        if self._fixed_partitions:
+            partitions = [
+                confluent_kafka.TopicPartition(self._kafka_topic, p.value)
+                for p in self._fixed_partitions
+            ]
+            self._consumer.assign(partitions)
+        else:
+            self._consumer.subscribe([self._kafka_topic])
+
+        self._running = True
+        self._poll_thread = threading.Thread(
+            target=self._poll_loop,
+            name=f"kafka-subscriber-poll-{group_id}",
+            daemon=True,
+        )
+        self._poll_thread.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        self._running = False
+        if self._poll_thread and self._poll_thread.is_alive():
+            # We must run join in executor to avoid blocking loop
+            await self._loop.run_in_executor(None, self._poll_thread.join)
+        if self._consumer:
+            # Close consumer in executor too as it might block
+            await self._loop.run_in_executor(None, self._consumer.close)
+
+    def _poll_loop(self):
+        while self._running:
+            # 1. Process pending commits
+            self._process_commits()
+
+            # 2. Poll for messages
+            # Use short timeout to allow quick shutdown and commit processing
+            msg = self._consumer.poll(0.1)
+            if msg is None:
+                continue
+            if msg.error():
+                # Handle error
+                if msg.error().code() == confluent_kafka.KafkaError._PARTITION_EOF:
+                    continue
+                else:
+                    logger.error(f"Kafka consumer error: {msg.error()}")
+                    # We should probably fail the subscriber here.
+                    # In asyncio, we can propagate exception to the queue.
+                    self._loop.call_soon_threadsafe(
+                        self._queue.put_nowait, msg.error()
+                    )
+                    break
+
+            # 3. Process message
+            try:
+                wrapped_msg = self._convert_message(msg)
+                self._loop.call_soon_threadsafe(self._queue.put_nowait, wrapped_msg)
+            except Exception as e:
+                logger.exception("Failed to process consumer record")
+
+    def _process_commits(self):
+        latest_offsets = {}
+        while True:
+            try:
+                partition, offset = self._commit_queue.get_nowait()
+                latest_offsets[partition] = max(
+                    latest_offsets.get(partition, -1), offset
+                )
+            except queue.Empty:
+                break
+
+        if latest_offsets:
+            offsets_to_commit = [
+                confluent_kafka.TopicPartition(self._kafka_topic, p, o + 1)
+                for p, o in latest_offsets.items()
+            ]
+            try:
+                # Commit asynchronously
+                self._consumer.commit(offsets=offsets_to_commit, asynchronous=True)
+            except Exception as e:
+                logger.error(f"Failed to commit offsets: {e}")
+
+    def _on_ack(self, ack_id: AckId, should_ack: bool):
+        if should_ack:
+            self._commit_queue.put((ack_id.generation, ack_id.offset))
+        else:
+            # Nack behavior: just log, don't commit.
+            # Redelivery will happen on rebalance or restart.
+            logger.info(
+                f"Message nacked, offset {ack_id.offset} on partition {ack_id.generation} will not be committed."
+            )
+
+    def _convert_message(self, msg) -> Message:
+        pb = PubsubMessage.meta.pb()
+        if msg.value() is not None:
+            pb.data = msg.value()
+        if msg.key() is not None:
+            pb.ordering_key = msg.key().decode("utf-8", errors="replace")
+
+        # Convert timestamp
+        ts_type, ts_val = msg.timestamp()
+        if ts_type != confluent_kafka.TIMESTAMP_NOT_AVAILABLE and ts_val > 0:
+            seconds = ts_val // 1000
+            nanos = (ts_val % 1000) * 1_000_000
+            pb.publish_time.seconds = seconds
+            pb.publish_time.nanos = nanos
+
+        # Convert headers
+        headers = msg.headers()
+        header_counts = {}
+        if headers:
+            for k, v in headers:
+                if k == "pubsublite.event_time":
+                    ts = _parse_event_time_header(v)
+                    if ts:
+                        from google.cloud.pubsublite.cloudpubsub.message_transforms import (
+                            _encode_attribute_event_time_proto,
+                        )
+
+                        pb.attributes[
+                            "x-goog-pubsublite-event-time"
+                        ] = _encode_attribute_event_time_proto(ts)
+                    continue
+
+                # Handle duplicates by appending index suffix
+                count = header_counts.get(k, 0)
+                if count == 0:
+                    pb.attributes[k] = v.decode("utf-8", errors="replace")
+                else:
+                    pb.attributes[f"{k}.{count}"] = v.decode(
+                        "utf-8", errors="replace"
+                    )
+                header_counts[k] = count + 1
+
+        # Add Kafka metadata
+        pb.attributes["x-kafka-topic"] = msg.topic()
+        pb.attributes["x-kafka-partition"] = str(msg.partition())
+        pb.attributes["x-kafka-offset"] = str(msg.offset())
+        pb.attributes["x-kafka-timestamp-ms"] = str(ts_val)
+
+        # Standard message wrapper needs AckId
+        # We map generation -> partition, offset -> offset
+        ack_id = AckId(generation=msg.partition(), offset=msg.offset())
+
+        # Wrap it in standard Message class
+        # We wrap the proto-plus Message which wraps the pb
+        from google.pubsub_v1 import PubsubMessage as ProtoPlusPubsubMessage
+
+        wrapped_pb = ProtoPlusPubsubMessage()
+        wrapped_pb._pb = pb
+
+        # Message ID is topic:partition:offset
+        wrapped_pb.message_id = f"{msg.topic()}:{msg.partition()}:{msg.offset()}"
+
+        return WrappedMessage(
+            pb=wrapped_pb._pb,
+            ack_id=ack_id,
+            ack_handler=self._on_ack,
+        )
+
+    async def read(self) -> List[Message]:
+        # Wait for at least one item (could be message or error)
+        item = await self._queue.get()
+        if isinstance(item, Exception):
+            raise item
+
+        batch = [item]
+        # Pull more if available
+        while not self._queue.empty() and len(batch) < 100:
+            next_item = self._queue.get_nowait()
+            if isinstance(next_item, Exception):
+                raise next_item
+            batch.append(next_item)
+        return batch

--- a/google/cloud/pubsublite/cloudpubsub/internal/make_subscriber.py
+++ b/google/cloud/pubsublite/cloudpubsub/internal/make_subscriber.py
@@ -222,9 +222,7 @@ def make_async_subscriber(
                 "bootstrap_servers must be set when backend is MANAGED_KAFKA"
             )
         if not kafka_topic:
-            raise ValueError(
-                "kafka_topic must be set when backend is MANAGED_KAFKA"
-            )
+            raise ValueError("kafka_topic must be set when backend is MANAGED_KAFKA")
         from google.cloud.pubsublite.cloudpubsub.internal.kafka_subscriber import (
             KafkaAsyncSingleSubscriber,
         )

--- a/google/cloud/pubsublite/cloudpubsub/internal/make_subscriber.py
+++ b/google/cloud/pubsublite/cloudpubsub/internal/make_subscriber.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Mapping, Set, AsyncIterator, Callable
+from typing import Optional, Mapping, Set, AsyncIterator, Callable, Any
 from uuid import uuid4
 
 from google.api_core.client_options import ClientOptions
 from google.auth.credentials import Credentials
+from google.cloud.pubsublite.cloudpubsub.messaging_backend import MessagingBackend
 
 from google.cloud.pubsublite.cloudpubsub.reassignment_handler import (
     ReassignmentHandler,
@@ -189,6 +190,10 @@ def make_async_subscriber(
     credentials: Optional[Credentials] = None,
     client_options: Optional[ClientOptions] = None,
     metadata: Optional[Mapping[str, str]] = None,
+    backend: MessagingBackend = MessagingBackend.PUBSUB_LITE,
+    bootstrap_servers: Optional[str] = None,
+    kafka_topic: Optional[str] = None,
+    kafka_properties: Optional[Mapping[str, Any]] = None,
 ) -> AsyncSingleSubscriber:
     """
     Make a Pub/Sub Lite AsyncSubscriber.
@@ -196,18 +201,42 @@ def make_async_subscriber(
     Args:
       subscription: The subscription to subscribe to.
       transport: The transport type to use.
-      per_partition_flow_control_settings: The flow control settings for each partition subscribed to. Note that these
-        settings apply to each partition individually, not in aggregate.
+      per_partition_flow_control_settings: The flow control settings for each partition subscribed to. Only used for PUBSUB_LITE backend.
       nack_handler: An optional handler for when nack() is called on a Message. The default will fail the client.
       message_transformer: An optional transformer from Pub/Sub Lite messages to Cloud Pub/Sub messages.
       fixed_partitions: A fixed set of partitions to subscribe to. If not present, will instead use auto-assignment.
-      credentials: The credentials to use to connect. GOOGLE_DEFAULT_CREDENTIALS is used if None.
-      client_options: Other options to pass to the client. Note that if you pass any you must set api_endpoint.
+      credentials: The credentials to use to connect. Only used for PUBSUB_LITE backend.
+      client_options: Other options to pass to the client. Only used for PUBSUB_LITE backend.
       metadata: Additional metadata to send with the RPC.
+      backend: The messaging backend to use.
+      bootstrap_servers: The Kafka bootstrap servers. Required if backend is MANAGED_KAFKA.
+      kafka_topic: The Kafka topic name. Required if backend is MANAGED_KAFKA.
+      kafka_properties: Additional configuration properties for the Kafka consumer. Only used if backend is MANAGED_KAFKA.
 
     Returns:
       A new AsyncSubscriber.
     """
+    if backend == MessagingBackend.MANAGED_KAFKA:
+        if not bootstrap_servers:
+            raise ValueError(
+                "bootstrap_servers must be set when backend is MANAGED_KAFKA"
+            )
+        if not kafka_topic:
+            raise ValueError(
+                "kafka_topic must be set when backend is MANAGED_KAFKA"
+            )
+        from google.cloud.pubsublite.cloudpubsub.internal.kafka_subscriber import (
+            KafkaAsyncSingleSubscriber,
+        )
+
+        return KafkaAsyncSingleSubscriber(
+            subscription=subscription,
+            fixed_partitions=fixed_partitions,
+            bootstrap_servers=bootstrap_servers,
+            kafka_topic=kafka_topic,
+            kafka_properties=kafka_properties,
+        )
+
     metadata = merge_metadata(pubsub_context(framework="CLOUD_PUBSUB_SHIM"), metadata)
     if client_options is None:
         client_options = ClientOptions(

--- a/google/cloud/pubsublite/cloudpubsub/messaging_backend.py
+++ b/google/cloud/pubsublite/cloudpubsub/messaging_backend.py
@@ -1,0 +1,22 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+
+
+class MessagingBackend(Enum):
+    """The messaging backend to use for the client."""
+
+    PUBSUB_LITE = 1
+    MANAGED_KAFKA = 2

--- a/google/cloud/pubsublite/cloudpubsub/publisher_client.py
+++ b/google/cloud/pubsublite/cloudpubsub/publisher_client.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 from concurrent.futures import Future
-from typing import Optional, Mapping, Union
+from typing import Optional, Mapping, Union, Any
 from uuid import uuid4
+
+from google.cloud.pubsublite.cloudpubsub.messaging_backend import MessagingBackend
 
 from google.api_core.client_options import ClientOptions
 from google.auth.credentials import Credentials
@@ -74,28 +76,48 @@ class PublisherClient(PublisherClientInterface, ConstructableFromServiceAccount)
         transport: str = "grpc_asyncio",
         client_options: Optional[ClientOptions] = None,
         enable_idempotence: bool = False,
+        backend: MessagingBackend = MessagingBackend.PUBSUB_LITE,
+        bootstrap_servers: Optional[str] = None,
+        kafka_properties: Optional[Mapping[str, Any]] = None,
     ):
         """
         Create a new PublisherClient.
 
         Args:
-            per_partition_batching_settings: The settings for publish batching. Apply on a per-partition basis.
-            credentials: If provided, the credentials to use when connecting.
-            transport: The transport to use. Must correspond to an asyncio transport.
-            client_options: The client options to use when connecting. If used, must explicitly set `api_endpoint`.
-            enable_idempotence: Whether idempotence is enabled, where the server will ensure that unique messages within a single publisher session are stored only once.
+            per_partition_batching_settings: The settings for publish batching. Apply on a per-partition basis. Only used for PUBSUB_LITE backend.
+            credentials: If provided, the credentials to use when connecting. Only used for PUBSUB_LITE backend.
+            transport: The transport to use. Must correspond to an asyncio transport. Only used for PUBSUB_LITE backend.
+            client_options: The client options to use when connecting. If used, must explicitly set `api_endpoint`. Only used for PUBSUB_LITE backend.
+            enable_idempotence: Whether idempotence is enabled. Only used for PUBSUB_LITE backend.
+            backend: The messaging backend to use.
+            bootstrap_servers: The Kafka bootstrap servers. Required if backend is MANAGED_KAFKA.
+            kafka_properties: Additional configuration properties for the Kafka producer. Only used if backend is MANAGED_KAFKA.
         """
-        client_id = _get_client_id(enable_idempotence)
-        self._impl = MultiplexedPublisherClient(
-            lambda topic: make_publisher(
-                topic=topic,
-                per_partition_batching_settings=per_partition_batching_settings,
-                credentials=credentials,
-                client_options=client_options,
-                transport=transport,
-                client_id=client_id,
+        if backend == MessagingBackend.MANAGED_KAFKA:
+            if not bootstrap_servers:
+                raise ValueError(
+                    "bootstrap_servers must be set when backend is MANAGED_KAFKA"
+                )
+            from google.cloud.pubsublite.cloudpubsub.internal.kafka_publisher import (
+                KafkaPublisherClient,
             )
-        )
+
+            self._impl = KafkaPublisherClient(
+                bootstrap_servers=bootstrap_servers,
+                kafka_properties=kafka_properties,
+            )
+        else:
+            client_id = _get_client_id(enable_idempotence)
+            self._impl = MultiplexedPublisherClient(
+                lambda topic: make_publisher(
+                    topic=topic,
+                    per_partition_batching_settings=per_partition_batching_settings,
+                    credentials=credentials,
+                    client_options=client_options,
+                    transport=transport,
+                    client_id=client_id,
+                )
+            )
         self._require_started = RequireStarted()
 
     @overrides
@@ -149,28 +171,48 @@ class AsyncPublisherClient(
         transport: str = "grpc_asyncio",
         client_options: Optional[ClientOptions] = None,
         enable_idempotence: bool = False,
+        backend: MessagingBackend = MessagingBackend.PUBSUB_LITE,
+        bootstrap_servers: Optional[str] = None,
+        kafka_properties: Optional[Mapping[str, Any]] = None,
     ):
         """
         Create a new AsyncPublisherClient.
 
         Args:
-            per_partition_batching_settings: The settings for publish batching. Apply on a per-partition basis.
-            credentials: If provided, the credentials to use when connecting.
-            transport: The transport to use. Must correspond to an asyncio transport.
-            client_options: The client options to use when connecting. If used, must explicitly set `api_endpoint`.
-            enable_idempotence: Whether idempotence is enabled, where the server will ensure that unique messages within a single publisher session are stored only once.
+            per_partition_batching_settings: The settings for publish batching. Apply on a per-partition basis. Only used for PUBSUB_LITE backend.
+            credentials: If provided, the credentials to use when connecting. Only used for PUBSUB_LITE backend.
+            transport: The transport to use. Must correspond to an asyncio transport. Only used for PUBSUB_LITE backend.
+            client_options: The client options to use when connecting. If used, must explicitly set `api_endpoint`. Only used for PUBSUB_LITE backend.
+            enable_idempotence: Whether idempotence is enabled. Only used for PUBSUB_LITE backend.
+            backend: The messaging backend to use.
+            bootstrap_servers: The Kafka bootstrap servers. Required if backend is MANAGED_KAFKA.
+            kafka_properties: Additional configuration properties for the Kafka producer. Only used if backend is MANAGED_KAFKA.
         """
-        client_id = _get_client_id(enable_idempotence)
-        self._impl = MultiplexedAsyncPublisherClient(
-            lambda topic: make_async_publisher(
-                topic=topic,
-                per_partition_batching_settings=per_partition_batching_settings,
-                credentials=credentials,
-                client_options=client_options,
-                transport=transport,
-                client_id=client_id,
+        if backend == MessagingBackend.MANAGED_KAFKA:
+            if not bootstrap_servers:
+                raise ValueError(
+                    "bootstrap_servers must be set when backend is MANAGED_KAFKA"
+                )
+            from google.cloud.pubsublite.cloudpubsub.internal.kafka_publisher import (
+                AsyncKafkaPublisherClient,
             )
-        )
+
+            self._impl = AsyncKafkaPublisherClient(
+                bootstrap_servers=bootstrap_servers,
+                kafka_properties=kafka_properties,
+            )
+        else:
+            client_id = _get_client_id(enable_idempotence)
+            self._impl = MultiplexedAsyncPublisherClient(
+                lambda topic: make_async_publisher(
+                    topic=topic,
+                    per_partition_batching_settings=per_partition_batching_settings,
+                    credentials=credentials,
+                    client_options=client_options,
+                    transport=transport,
+                    client_id=client_id,
+                )
+            )
         self._require_started = RequireStarted()
 
     @overrides

--- a/google/cloud/pubsublite/cloudpubsub/subscriber_client.py
+++ b/google/cloud/pubsublite/cloudpubsub/subscriber_client.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 from concurrent.futures.thread import ThreadPoolExecutor
-from typing import Optional, Union, Set, AsyncIterator
+from typing import Optional, Union, Set, AsyncIterator, Any, Mapping
 
+from google.cloud.pubsublite.cloudpubsub.messaging_backend import MessagingBackend
 from google.api_core.client_options import ClientOptions
 from google.auth.credentials import Credentials
 from google.cloud.pubsub_v1.subscriber.futures import StreamingPullFuture
@@ -70,18 +71,37 @@ class SubscriberClient(SubscriberClientInterface, ConstructableFromServiceAccoun
         credentials: Optional[Credentials] = None,
         transport: str = "grpc_asyncio",
         client_options: Optional[ClientOptions] = None,
+        backend: MessagingBackend = MessagingBackend.PUBSUB_LITE,
+        bootstrap_servers: Optional[str] = None,
+        kafka_topic: Optional[str] = None,
+        kafka_properties: Optional[Mapping[str, Any]] = None,
     ):
         """
         Create a new SubscriberClient.
 
         Args:
-            executor: A ThreadPoolExecutor to use. The client will shut it down on __exit__. If provided a single threaded executor, messages will be ordered per-partition, but take care that the callback does not block for too long as it will impede forward progress on all subscriptions.
-            nack_handler: A handler for when `nack()` is called. The default NackHandler raises an exception and fails the subscribe stream.
-            message_transformer: A transformer from Pub/Sub Lite messages to Cloud Pub/Sub messages. This may not return a message with "message_id" set.
-            credentials: If provided, the credentials to use when connecting.
-            transport: The transport to use. Must correspond to an asyncio transport.
-            client_options: The client options to use when connecting. If used, must explicitly set `api_endpoint`.
+            executor: A ThreadPoolExecutor to use. The client will shut it down on __exit__.
+            nack_handler: A handler for when `nack()` is called.
+            reassignment_handler: A handler for when partitions are reassigned. Only used for PUBSUB_LITE backend.
+            message_transformer: A transformer from Pub/Sub Lite messages to Cloud Pub/Sub messages.
+            credentials: If provided, the credentials to use when connecting. Only used for PUBSUB_LITE backend.
+            transport: The transport to use. Only used for PUBSUB_LITE backend.
+            client_options: The client options to use when connecting. Only used for PUBSUB_LITE backend.
+            backend: The messaging backend to use.
+            bootstrap_servers: The Kafka bootstrap servers. Required if backend is MANAGED_KAFKA.
+            kafka_topic: The Kafka topic name. Required if backend is MANAGED_KAFKA.
+            kafka_properties: Additional configuration properties for the Kafka consumer. Only used if backend is MANAGED_KAFKA.
         """
+        if backend == MessagingBackend.MANAGED_KAFKA:
+            if not bootstrap_servers:
+                raise ValueError(
+                    "bootstrap_servers must be set when backend is MANAGED_KAFKA"
+                )
+            if not kafka_topic:
+                raise ValueError(
+                    "kafka_topic must be set when backend is MANAGED_KAFKA"
+                )
+
         if executor is None:
             executor = ThreadPoolExecutor()
         self._impl = MultiplexedSubscriberClient(
@@ -96,6 +116,10 @@ class SubscriberClient(SubscriberClientInterface, ConstructableFromServiceAccoun
                 fixed_partitions=partitions,
                 credentials=credentials,
                 client_options=client_options,
+                backend=backend,
+                bootstrap_servers=bootstrap_servers,
+                kafka_topic=kafka_topic,
+                kafka_properties=kafka_properties,
             ),
         )
         self._require_started = RequireStarted()
@@ -151,17 +175,36 @@ class AsyncSubscriberClient(
         credentials: Optional[Credentials] = None,
         transport: str = "grpc_asyncio",
         client_options: Optional[ClientOptions] = None,
+        backend: MessagingBackend = MessagingBackend.PUBSUB_LITE,
+        bootstrap_servers: Optional[str] = None,
+        kafka_topic: Optional[str] = None,
+        kafka_properties: Optional[Mapping[str, Any]] = None,
     ):
         """
         Create a new AsyncSubscriberClient.
 
         Args:
-            nack_handler: A handler for when `nack()` is called. The default NackHandler raises an exception and fails the subscribe stream.
-            message_transformer: A transformer from Pub/Sub Lite messages to Cloud Pub/Sub messages. This may not return a message with "message_id" set.
-            credentials: If provided, the credentials to use when connecting.
-            transport: The transport to use. Must correspond to an asyncio transport.
-            client_options: The client options to use when connecting. If used, must explicitly set `api_endpoint`.
+            nack_handler: A handler for when `nack()` is called.
+            reassignment_handler: A handler for when partitions are reassigned. Only used for PUBSUB_LITE backend.
+            message_transformer: A transformer from Pub/Sub Lite messages to Cloud Pub/Sub messages.
+            credentials: If provided, the credentials to use when connecting. Only used for PUBSUB_LITE backend.
+            transport: The transport to use. Only used for PUBSUB_LITE backend.
+            client_options: The client options to use when connecting. Only used for PUBSUB_LITE backend.
+            backend: The messaging backend to use.
+            bootstrap_servers: The Kafka bootstrap servers. Required if backend is MANAGED_KAFKA.
+            kafka_topic: The Kafka topic name. Required if backend is MANAGED_KAFKA.
+            kafka_properties: Additional configuration properties for the Kafka consumer. Only used if backend is MANAGED_KAFKA.
         """
+        if backend == MessagingBackend.MANAGED_KAFKA:
+            if not bootstrap_servers:
+                raise ValueError(
+                    "bootstrap_servers must be set when backend is MANAGED_KAFKA"
+                )
+            if not kafka_topic:
+                raise ValueError(
+                    "kafka_topic must be set when backend is MANAGED_KAFKA"
+                )
+
         self._impl = MultiplexedAsyncSubscriberClient(
             lambda subscription, partitions, settings: make_async_subscriber(
                 subscription=subscription,
@@ -173,6 +216,10 @@ class AsyncSubscriberClient(
                 fixed_partitions=partitions,
                 credentials=credentials,
                 client_options=client_options,
+                backend=backend,
+                bootstrap_servers=bootstrap_servers,
+                kafka_topic=kafka_topic,
+                kafka_properties=kafka_properties,
             )
         )
         self._require_started = RequireStarted()

--- a/google/cloud/pubsublite/internal/gmk_auth.py
+++ b/google/cloud/pubsublite/internal/gmk_auth.py
@@ -32,7 +32,10 @@ def _b64_encode(data: str) -> str:
 
 def _extract_email(credentials) -> str:
     # Attempt to extract email from credentials
-    if hasattr(credentials, "service_account_email") and credentials.service_account_email:
+    if (
+        hasattr(credentials, "service_account_email")
+        and credentials.service_account_email
+    ):
         return credentials.service_account_email
     if hasattr(credentials, "signer_email") and credentials.signer_email:
         return credentials.signer_email
@@ -87,7 +90,11 @@ def gcp_oauth_callback(oauth_config: str) -> Tuple[str, float]:
 
     header_b64 = _b64_encode(header_json)
     claims_b64 = _b64_encode(claims_json)
-    token_b64 = base64.urlsafe_b64encode(credentials.token.encode("utf-8")).decode("utf-8").rstrip("=")
+    token_b64 = (
+        base64.urlsafe_b64encode(credentials.token.encode("utf-8"))
+        .decode("utf-8")
+        .rstrip("=")
+    )
 
     kafka_token = f"{header_b64}.{claims_b64}.{token_b64}"
     return kafka_token, float(expiry)

--- a/google/cloud/pubsublite/internal/gmk_auth.py
+++ b/google/cloud/pubsublite/internal/gmk_auth.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import json
+import time
+import urllib.request
+from typing import Tuple
+
+import google.auth
+import google.auth.transport.requests
+
+# Static JWT header matching Java/Go implementations
+GMK_JWT_HEADER = {"typ": "JWT", "alg": "GOOG_OAUTH2_TOKEN"}
+
+
+def _b64_encode(data: str) -> str:
+    # base64url encoding without padding
+    return base64.urlsafe_b64encode(data.encode("utf-8")).decode("utf-8").rstrip("=")
+
+
+def _extract_email(credentials) -> str:
+    # Attempt to extract email from credentials
+    if hasattr(credentials, "service_account_email") and credentials.service_account_email:
+        return credentials.service_account_email
+    if hasattr(credentials, "signer_email") and credentials.signer_email:
+        return credentials.signer_email
+
+    # Fallback to userinfo endpoint if we have a token
+    if hasattr(credentials, "token") and credentials.token:
+        try:
+            req = urllib.request.Request(
+                "https://www.googleapis.com/oauth2/v3/userinfo",
+                headers={"Authorization": f"Bearer {credentials.token}"},
+            )
+            # Use a short timeout to avoid blocking indefinitely
+            with urllib.request.urlopen(req, timeout=5) as response:
+                info = json.loads(response.read().decode("utf-8"))
+                return info.get("email", "")
+        except Exception:
+            pass
+    return ""
+
+
+def gcp_oauth_callback(oauth_config: str) -> Tuple[str, float]:
+    """Callback for confluent-kafka OAUTHBEARER authentication.
+
+    Args:
+        oauth_config: Custom configuration string from sasl.oauthbearer.config (ignored).
+
+    Returns:
+        A tuple of (token_value_str, expiry_time_seconds_since_epoch).
+    """
+    credentials, _ = google.auth.default(
+        scopes=["https://www.googleapis.com/auth/cloud-platform"]
+    )
+    auth_request = google.auth.transport.requests.Request()
+    credentials.refresh(auth_request)
+
+    email = _extract_email(credentials)
+    now = int(time.time())
+    # Default to 1 hour if expiry is not available
+    expiry = int(credentials.expiry.timestamp()) if credentials.expiry else now + 3600
+
+    claims = {
+        "exp": expiry,
+        "iat": now,
+        "scope": "kafka",
+        "sub": email,
+    }
+
+    # Token format: base64url(header).base64url(claims).base64url(access_token)
+    # Ensure separators are compact (no spaces) to match Go/Java JSON encoding exactly
+    header_json = json.dumps(GMK_JWT_HEADER, separators=(",", ":"))
+    claims_json = json.dumps(claims, separators=(",", ":"))
+
+    header_b64 = _b64_encode(header_json)
+    claims_b64 = _b64_encode(claims_json)
+    token_b64 = base64.urlsafe_b64encode(credentials.token.encode("utf-8")).decode("utf-8").rstrip("=")
+
+    kafka_token = f"{header_b64}.{claims_b64}.{token_b64}"
+    return kafka_token, float(expiry)

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,9 @@ setuptools.setup(
     packages=packages,
     python_requires=">=3.8",
     install_requires=dependencies,
+    extras_require={
+        "kafka": ["confluent-kafka >= 2.0.0, < 3.0.0"],
+    },
     include_package_data=True,
     zip_safe=False,
 )

--- a/tests/unit/pubsublite/cloudpubsub/internal/kafka_publisher_test.py
+++ b/tests/unit/pubsublite/cloudpubsub/internal/kafka_publisher_test.py
@@ -1,0 +1,226 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+import asyncio
+
+# Mock confluent_kafka module before it is imported in the code under test
+mock_confluent_kafka = MagicMock()
+sys.modules["confluent_kafka"] = mock_confluent_kafka
+
+from google.cloud.pubsublite.cloudpubsub.internal.kafka_publisher import (
+    KafkaPublisherClient,
+    AsyncKafkaPublisherClient,
+)
+from google.cloud.pubsublite.types import TopicPath
+from google.api_core.exceptions import InternalServerError
+
+
+@pytest.fixture(autouse=True)
+def reset_mock():
+    mock_confluent_kafka.reset_mock()
+    mock_confluent_kafka.Producer = MagicMock()
+
+
+def test_sync_kafka_publisher_client_lifecycle():
+    bootstrap_servers = "localhost:9092"
+    kafka_properties = {"client.id": "test-client"}
+
+    with KafkaPublisherClient(bootstrap_servers, kafka_properties) as client:
+        mock_confluent_kafka.Producer.assert_called_once()
+        config = mock_confluent_kafka.Producer.call_args[0][0]
+        assert config["bootstrap.servers"] == bootstrap_servers
+        assert config["client.id"] == "test-client"
+        assert config["security.protocol"] == "SASL_SSL"
+        assert config["sasl.mechanisms"] == "OAUTHBEARER"
+        assert config["oauth_cb"] is not None
+        assert config["enable.idempotence"] is True
+
+        assert client._poll_thread.is_alive()
+
+    # After exiting block, it should shutdown
+    assert not client._running
+    client._producer.flush.assert_called_once()
+
+
+def test_sync_kafka_publish_success():
+    bootstrap_servers = "localhost:9092"
+    producer_mock = MagicMock()
+    mock_confluent_kafka.Producer.return_value = producer_mock
+
+    # Capture callback
+    callback_capture = []
+
+    def mock_produce(topic, value, key, headers, callback):
+        callback_capture.append(callback)
+
+    producer_mock.produce.side_effect = mock_produce
+
+    with KafkaPublisherClient(bootstrap_servers) as client:
+        future = client.publish(
+            topic="projects/p/locations/l/topics/t",
+            data=b"payload",
+            ordering_key="key",
+            attr1="val1",
+        )
+
+        producer_mock.produce.assert_called_once()
+        call_kwargs = producer_mock.produce.call_args[1]
+        assert call_kwargs["topic"] == "projects/p/locations/l/topics/t"
+        assert call_kwargs["value"] == b"payload"
+        assert call_kwargs["key"] == b"key"
+        assert ("attr1", b"val1") in call_kwargs["headers"]
+
+        # Trigger callback with success
+        mock_msg = MagicMock()
+        mock_msg.partition.return_value = 2
+        mock_msg.offset.return_value = 100
+        callback_capture[0](None, mock_msg)
+
+        assert future.done()
+        assert future.result() == "2:100"
+
+
+def test_sync_kafka_publish_failure():
+    bootstrap_servers = "localhost:9092"
+    producer_mock = MagicMock()
+    mock_confluent_kafka.Producer.return_value = producer_mock
+
+    callback_capture = []
+
+    def mock_produce(topic, value, key, headers, callback):
+        callback_capture.append(callback)
+
+    producer_mock.produce.side_effect = mock_produce
+
+    with KafkaPublisherClient(bootstrap_servers) as client:
+        future = client.publish(
+            topic="projects/p/locations/l/topics/t", data=b"payload"
+        )
+
+        # Trigger callback with error
+        callback_capture[0]("some_kafka_error", None)
+
+        assert future.done()
+        with pytest.raises(InternalServerError):
+            future.result()
+
+
+@patch(
+    "google.cloud.pubsublite.cloudpubsub.message_transforms._decode_attribute_event_time_proto"
+)
+def test_sync_kafka_publish_with_event_time(mock_decode):
+    mock_ts = MagicMock()
+    mock_ts.seconds = 12345
+    mock_ts.nanos = 67890
+    mock_decode.return_value = mock_ts
+
+    bootstrap_servers = "localhost:9092"
+    producer_mock = MagicMock()
+    mock_confluent_kafka.Producer.return_value = producer_mock
+
+    with KafkaPublisherClient(bootstrap_servers) as client:
+        client.publish(
+            topic="projects/p/locations/l/topics/t",
+            data=b"payload",
+            **{"x-goog-pubsublite-event-time": "serialized_proto"},
+        )
+
+        call_kwargs = producer_mock.produce.call_args[1]
+        headers = call_kwargs["headers"]
+        assert ("pubsublite.event_time", b"12345.000067890") in headers
+        mock_decode.assert_called_once_with("serialized_proto")
+
+
+@pytest.mark.asyncio
+async def test_async_kafka_publisher_client_lifecycle():
+    bootstrap_servers = "localhost:9092"
+    client = AsyncKafkaPublisherClient(bootstrap_servers)
+    mock_confluent_kafka.Producer.assert_called_once()
+    assert client._poll_thread.is_alive()
+
+    async with client:
+        pass
+
+    assert not client._running
+    client._producer.flush.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_async_kafka_publish_success():
+    bootstrap_servers = "localhost:9092"
+    producer_mock = MagicMock()
+    mock_confluent_kafka.Producer.return_value = producer_mock
+
+    callback_capture = []
+
+    def mock_produce(topic, value, key, headers, callback):
+        callback_capture.append(callback)
+
+    producer_mock.produce.side_effect = mock_produce
+
+    client = AsyncKafkaPublisherClient(bootstrap_servers)
+    async with client:
+        publish_task = asyncio.create_task(
+            client.publish(
+                topic="projects/p/locations/l/topics/t",
+                data=b"payload",
+                ordering_key="key",
+            )
+        )
+
+        # Yield to let the publish call run and schedule
+        await asyncio.sleep(0.01)
+
+        producer_mock.produce.assert_called_once()
+
+        # Trigger callback with success (simulating background thread)
+        mock_msg = MagicMock()
+        mock_msg.partition.return_value = 3
+        mock_msg.offset.return_value = 200
+        callback_capture[0](None, mock_msg)
+
+        result = await publish_task
+        assert result == "3:200"
+
+
+@pytest.mark.asyncio
+async def test_async_kafka_publish_failure():
+    bootstrap_servers = "localhost:9092"
+    producer_mock = MagicMock()
+    mock_confluent_kafka.Producer.return_value = producer_mock
+
+    callback_capture = []
+
+    def mock_produce(topic, value, key, headers, callback):
+        callback_capture.append(callback)
+
+    producer_mock.produce.side_effect = mock_produce
+
+    client = AsyncKafkaPublisherClient(bootstrap_servers)
+    async with client:
+        publish_task = asyncio.create_task(
+            client.publish(
+                topic="projects/p/locations/l/topics/t", data=b"payload"
+            )
+        )
+
+        await asyncio.sleep(0.01)
+
+        callback_capture[0]("some_kafka_error", None)
+
+        with pytest.raises(InternalServerError):
+            await publish_task

--- a/tests/unit/pubsublite/cloudpubsub/internal/kafka_publisher_test.py
+++ b/tests/unit/pubsublite/cloudpubsub/internal/kafka_publisher_test.py
@@ -12,19 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-from unittest.mock import MagicMock, patch
-import pytest
 import asyncio
+from unittest.mock import MagicMock, patch
 
-mock_confluent_kafka = None
-
+from google.api_core.exceptions import InternalServerError
 from google.cloud.pubsublite.cloudpubsub.internal.kafka_publisher import (
     KafkaPublisherClient,
     AsyncKafkaPublisherClient,
 )
-from google.cloud.pubsublite.types import TopicPath
-from google.api_core.exceptions import InternalServerError
+import pytest
+
+mock_confluent_kafka = None
 
 
 @pytest.fixture(autouse=True)
@@ -211,9 +209,7 @@ async def test_async_kafka_publish_failure():
     client = AsyncKafkaPublisherClient(bootstrap_servers)
     async with client:
         publish_task = asyncio.create_task(
-            client.publish(
-                topic="projects/p/locations/l/topics/t", data=b"payload"
-            )
+            client.publish(topic="projects/p/locations/l/topics/t", data=b"payload")
         )
 
         await asyncio.sleep(0.01)

--- a/tests/unit/pubsublite/cloudpubsub/internal/kafka_publisher_test.py
+++ b/tests/unit/pubsublite/cloudpubsub/internal/kafka_publisher_test.py
@@ -17,9 +17,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import asyncio
 
-# Mock confluent_kafka module before it is imported in the code under test
-mock_confluent_kafka = MagicMock()
-sys.modules["confluent_kafka"] = mock_confluent_kafka
+mock_confluent_kafka = None
 
 from google.cloud.pubsublite.cloudpubsub.internal.kafka_publisher import (
     KafkaPublisherClient,
@@ -30,9 +28,9 @@ from google.api_core.exceptions import InternalServerError
 
 
 @pytest.fixture(autouse=True)
-def reset_mock():
-    mock_confluent_kafka.reset_mock()
-    mock_confluent_kafka.Producer = MagicMock()
+def setup_local_mock(confluent_kafka_mock):
+    global mock_confluent_kafka
+    mock_confluent_kafka = confluent_kafka_mock
 
 
 def test_sync_kafka_publisher_client_lifecycle():

--- a/tests/unit/pubsublite/cloudpubsub/internal/kafka_subscriber_test.py
+++ b/tests/unit/pubsublite/cloudpubsub/internal/kafka_subscriber_test.py
@@ -12,18 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-from unittest.mock import MagicMock, call
-import pytest
 import asyncio
 from datetime import datetime, timezone
-
-mock_confluent_kafka = None
+from unittest.mock import MagicMock, call
 
 from google.cloud.pubsublite.cloudpubsub.internal.kafka_subscriber import (
     KafkaAsyncSingleSubscriber,
 )
 from google.cloud.pubsublite.types import SubscriptionPath, Partition
+import pytest
+
+mock_confluent_kafka = None
 
 pytestmark = pytest.mark.asyncio
 
@@ -43,7 +42,6 @@ def consumer_mock():
 
 
 class MockMessage:
-
     def __init__(
         self,
         value=b"val",
@@ -107,8 +105,7 @@ async def test_kafka_subscriber_lifecycle_subscribe(consumer_mock):
         assert config["bootstrap.servers"] == bootstrap_servers
         # Derived group ID: slashes replaced by dashes
         assert (
-            config["group.id"]
-            == "projects-p-locations-us-central1-a-subscriptions-s"
+            config["group.id"] == "projects-p-locations-us-central1-a-subscriptions-s"
         )
         assert config["enable.auto.commit"] is False
 

--- a/tests/unit/pubsublite/cloudpubsub/internal/kafka_subscriber_test.py
+++ b/tests/unit/pubsublite/cloudpubsub/internal/kafka_subscriber_test.py
@@ -1,0 +1,307 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from unittest.mock import MagicMock, call
+import pytest
+import asyncio
+from datetime import datetime, timezone
+
+mock_confluent_kafka = None
+
+from google.cloud.pubsublite.cloudpubsub.internal.kafka_subscriber import (
+    KafkaAsyncSingleSubscriber,
+)
+from google.cloud.pubsublite.types import SubscriptionPath, Partition
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def setup_local_mock(confluent_kafka_mock):
+    global mock_confluent_kafka
+    mock_confluent_kafka = confluent_kafka_mock
+
+
+@pytest.fixture()
+def consumer_mock():
+    mock = MagicMock()
+    mock.poll.return_value = None
+    mock_confluent_kafka.Consumer.return_value = mock
+    return mock
+
+
+class MockMessage:
+
+    def __init__(
+        self,
+        value=b"val",
+        key=b"key",
+        partition=0,
+        offset=0,
+        headers=None,
+        timestamp=(1, 1000),
+        err=None,
+    ):
+        self._value = value
+        self._key = key
+        self._partition = partition
+        self._offset = offset
+        self._headers = headers or []
+        self._timestamp = timestamp
+        self._err = err
+
+    def value(self):
+        return self._value
+
+    def key(self):
+        return self._key
+
+    def partition(self):
+        return self._partition
+
+    def offset(self):
+        return self._offset
+
+    def headers(self):
+        return self._headers
+
+    def timestamp(self):
+        return self._timestamp
+
+    def error(self):
+        return self._err
+
+    def topic(self):
+        return "test-topic"
+
+
+async def test_kafka_subscriber_lifecycle_subscribe(consumer_mock):
+    sub_path = SubscriptionPath.parse(
+        "projects/p/locations/us-central1-a/subscriptions/s"
+    )
+    bootstrap_servers = "localhost:9092"
+    kafka_topic = "test-topic"
+
+    subscriber = KafkaAsyncSingleSubscriber(
+        subscription=sub_path,
+        fixed_partitions=None,
+        bootstrap_servers=bootstrap_servers,
+        kafka_topic=kafka_topic,
+    )
+
+    async with subscriber:
+        mock_confluent_kafka.Consumer.assert_called_once()
+        config = mock_confluent_kafka.Consumer.call_args[0][0]
+        assert config["bootstrap.servers"] == bootstrap_servers
+        # Derived group ID: slashes replaced by dashes
+        assert (
+            config["group.id"]
+            == "projects-p-locations-us-central1-a-subscriptions-s"
+        )
+        assert config["enable.auto.commit"] is False
+
+        # Verify subscribe was called on consumer
+        consumer_mock.subscribe.assert_called_once_with([kafka_topic])
+        assert subscriber._poll_thread.is_alive()
+
+    # After exit, consumer should be closed
+    consumer_mock.close.assert_called_once()
+    assert not subscriber._running
+
+
+async def test_kafka_subscriber_lifecycle_assign(consumer_mock):
+    sub_path = SubscriptionPath.parse(
+        "projects/p/locations/us-central1-a/subscriptions/s"
+    )
+    bootstrap_servers = "localhost:9092"
+    kafka_topic = "test-topic"
+    fixed_partitions = {Partition(1), Partition(3)}
+
+    # Mock TopicPartition construction
+    tp_mock = MagicMock()
+    mock_confluent_kafka.TopicPartition = tp_mock
+
+    subscriber = KafkaAsyncSingleSubscriber(
+        subscription=sub_path,
+        fixed_partitions=fixed_partitions,
+        bootstrap_servers=bootstrap_servers,
+        kafka_topic=kafka_topic,
+    )
+
+    async with subscriber:
+        # Verify assign was called
+        # Order of partitions in set can vary, so check calls
+        tp_mock.assert_has_calls(
+            [call(kafka_topic, 1), call(kafka_topic, 3)], any_order=True
+        )
+        assert consumer_mock.assign.called
+        consumer_mock.subscribe.assert_not_called()
+
+
+async def test_kafka_subscriber_read_success(consumer_mock):
+    sub_path = SubscriptionPath.parse(
+        "projects/p/locations/us-central1-a/subscriptions/s"
+    )
+
+    # Return one message and then None
+    msg = MockMessage(value=b"payload", key=b"my-key", partition=1, offset=50)
+    poll_results = [msg]
+
+    def mock_poll(timeout):
+        return poll_results.pop(0) if poll_results else None
+
+    consumer_mock.poll.side_effect = mock_poll
+
+    subscriber = KafkaAsyncSingleSubscriber(
+        subscription=sub_path,
+        fixed_partitions=None,
+        bootstrap_servers="localhost",
+        kafka_topic="topic",
+    )
+
+    async with subscriber:
+        # Wait a bit for poll thread to run and put message in queue
+        await asyncio.sleep(0.1)
+
+        batch = await subscriber.read()
+        assert len(batch) == 1
+        wrapped_msg = batch[0]
+
+        assert wrapped_msg.data == b"payload"
+        assert wrapped_msg.ordering_key == "my-key"
+        assert wrapped_msg.message_id == "test-topic:1:50"
+        # Publish time: 1000ms -> 1s
+        assert wrapped_msg.publish_time == datetime(
+            1970, 1, 1, 0, 0, 1, tzinfo=timezone.utc
+        )
+
+        # Metadata attributes
+        assert wrapped_msg.attributes["x-kafka-topic"] == "test-topic"
+        assert wrapped_msg.attributes["x-kafka-partition"] == "1"
+        assert wrapped_msg.attributes["x-kafka-offset"] == "50"
+
+
+async def test_kafka_subscriber_read_with_event_time(consumer_mock):
+    sub_path = SubscriptionPath.parse(
+        "projects/p/locations/us-central1-a/subscriptions/s"
+    )
+
+    # Message with pubsublite.event_time header
+    headers = [("pubsublite.event_time", b"12345.000067890")]
+    msg = MockMessage(value=b"val", headers=headers)
+    poll_results = [msg]
+
+    def mock_poll(timeout):
+        return poll_results.pop(0) if poll_results else None
+
+    consumer_mock.poll.side_effect = mock_poll
+
+    subscriber = KafkaAsyncSingleSubscriber(
+        subscription=sub_path,
+        fixed_partitions=None,
+        bootstrap_servers="localhost",
+        kafka_topic="topic",
+    )
+
+    async with subscriber:
+        await asyncio.sleep(0.1)
+        batch = await subscriber.read()
+        wrapped_msg = batch[0]
+
+        # Verify event time attribute is set and encoded correctly
+        assert "x-goog-pubsublite-event-time" in wrapped_msg.attributes
+        from google.cloud.pubsublite.cloudpubsub.message_transforms import (
+            decode_attribute_event_time,
+        )
+
+        dt = decode_attribute_event_time(
+            wrapped_msg.attributes["x-goog-pubsublite-event-time"]
+        )
+        assert dt.timestamp() == 12345.000067
+
+
+async def test_kafka_subscriber_read_with_duplicate_headers(consumer_mock):
+    sub_path = SubscriptionPath.parse(
+        "projects/p/locations/us-central1-a/subscriptions/s"
+    )
+
+    # Duplicate headers
+    headers = [("h1", b"v1"), ("h1", b"v2"), ("h2", b"v3")]
+    msg = MockMessage(value=b"val", headers=headers)
+    poll_results = [msg]
+
+    def mock_poll(timeout):
+        return poll_results.pop(0) if poll_results else None
+
+    consumer_mock.poll.side_effect = mock_poll
+
+    subscriber = KafkaAsyncSingleSubscriber(
+        subscription=sub_path,
+        fixed_partitions=None,
+        bootstrap_servers="localhost",
+        kafka_topic="topic",
+    )
+
+    async with subscriber:
+        await asyncio.sleep(0.1)
+        batch = await subscriber.read()
+        wrapped_msg = batch[0]
+
+        # Flat map with suffixes for duplicates
+        assert wrapped_msg.attributes["h1"] == "v1"
+        assert wrapped_msg.attributes["h1.1"] == "v2"
+        assert wrapped_msg.attributes["h2"] == "v3"
+
+
+async def test_kafka_subscriber_ack_commit(consumer_mock):
+    sub_path = SubscriptionPath.parse(
+        "projects/p/locations/us-central1-a/subscriptions/s"
+    )
+
+    msg = MockMessage(partition=2, offset=99)
+    poll_results = [msg]
+
+    def mock_poll(timeout):
+        return poll_results.pop(0) if poll_results else None
+
+    consumer_mock.poll.side_effect = mock_poll
+
+    subscriber = KafkaAsyncSingleSubscriber(
+        subscription=sub_path,
+        fixed_partitions=None,
+        bootstrap_servers="localhost",
+        kafka_topic="topic",
+    )
+
+    # Mock TopicPartition for commit verification
+    tp_mock = MagicMock()
+    mock_confluent_kafka.TopicPartition = tp_mock
+
+    async with subscriber:
+        await asyncio.sleep(0.1)
+        batch = await subscriber.read()
+        wrapped_msg = batch[0]
+
+        # Ack the message
+        wrapped_msg.ack()
+
+        # Wait for commit queue to be processed in poll loop
+        await asyncio.sleep(0.2)
+
+        # Verify commit was called with offset + 1
+        tp_mock.assert_called_with("topic", 2, 100)
+        consumer_mock.commit.assert_called_once()
+        call_kwargs = consumer_mock.commit.call_args[1]
+        assert call_kwargs["asynchronous"] is True

--- a/tests/unit/pubsublite/conftest.py
+++ b/tests/unit/pubsublite/conftest.py
@@ -1,0 +1,37 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from unittest.mock import MagicMock
+import pytest
+
+# Create a single shared mock for confluent_kafka to avoid test isolation issues
+# due to lazy imports and module caching.
+shared_mock_confluent_kafka = MagicMock()
+sys.modules["confluent_kafka"] = shared_mock_confluent_kafka
+
+
+@pytest.fixture(autouse=True)
+def reset_confluent_kafka():
+    shared_mock_confluent_kafka.reset_mock()
+    shared_mock_confluent_kafka.Producer = MagicMock()
+    shared_mock_confluent_kafka.Consumer = MagicMock()
+    # TopicPartition needs to be a callable that returns a mock, or just a mock class.
+    # We use MagicMock as it behaves like a class when called.
+    shared_mock_confluent_kafka.TopicPartition = MagicMock
+
+
+@pytest.fixture()
+def confluent_kafka_mock():
+    return shared_mock_confluent_kafka


### PR DESCRIPTION
This PR implements Google Managed Kafka (GMK) backend support for the Python Pub/Sub Lite client.

It matches the Go implementation by adding:
1. Gating to PublisherClient and SubscriberClient to detect MessagingBackend.MANAGED_KAFKA and route to Kafka-based implementations.
2. KafkaPublisherClient (sync & async) using confluent_kafka.Producer.
3. KafkaAsyncSingleSubscriber (used in multiplexed subscriber clients) using confluent_kafka.Consumer with thread-safe offset commits.
4. Automatic consumer group ID derivation from Pub/Sub Lite subscription path.
5. Header translation including event time parsing and multi-valued header flattening.
6. OAuth callback support using Google credentials.

Tested thoroughly with unit tests mocking confluent_kafka.